### PR TITLE
#28: Fix copy

### DIFF
--- a/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
+++ b/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
@@ -52,10 +52,10 @@ internal class PhotoDisplayController
     private readonly ConcurrentDictionary<int, bool> _previewsBeingCached = new();
 
     private readonly ConcurrentStack<int> _toBeDiskCachedPreviews = new();
-    private readonly ManualResetEvent _diskCachingCanStart = new(false);
+    private readonly ManualResetEvent _diskCachingCanStart = new (false);
 
     private int _keyPressCounter;
-
+    
 
     private readonly CanvasControl _d2dCanvas;
     private readonly Win2dCanvasController _canvasController;
@@ -125,7 +125,7 @@ internal class PhotoDisplayController
             }
             Photo.PhotosCount = files.Count;
 
-            foreach (var s in files)
+            foreach (var s in files) 
                 _photos.Add(new Photo(s));
 
 
@@ -140,7 +140,7 @@ internal class PhotoDisplayController
             var previewCachingThread = new Thread(PreviewCacheBuilderDoWork) { IsBackground = true };
             previewCachingThread.Start();
             var hqCachingThread = new Thread(HqImageCacheBuilderDoWork)
-            { IsBackground = true, Priority = ThreadPriority.AboveNormal };
+                { IsBackground = true, Priority = ThreadPriority.AboveNormal };
             hqCachingThread.Start();
             var previewDiskCachingThread = new Thread(PreviewDiskCacherDoWork) { IsBackground = true };
             previewDiskCachingThread.Start();
@@ -185,7 +185,7 @@ internal class PhotoDisplayController
                 _previewsBeingCached.Remove(index, out _);
 
                 if (photo.Preview.PreviewFrom == DisplayItem.PreviewSource.FromDisk) { _toBeDiskCachedPreviews.Push(item); }
-
+                
                 if (Photo.CurrentDisplayIndex == index)
                     UpgradeImageIfNeeded(photo, DisplayLevel.PlaceHolder, DisplayLevel.Preview);
 
@@ -253,8 +253,8 @@ internal class PhotoDisplayController
                 {
                     try
                     {
-                        if (_cachedPreviews.TryGetValue(index, out var image) &&
-                            image.Preview != null &&
+                        if (_cachedPreviews.TryGetValue(index, out var image) && 
+                            image.Preview != null && 
                             image.Preview.PreviewFrom == DisplayItem.PreviewSource.FromDisk)
                         {
                             PhotoDiskCacher.Instance.PutInCache(image.FileName, image.Preview.Bitmap);
@@ -284,7 +284,7 @@ internal class PhotoDisplayController
         var keysToRemove = _cachedHqImages.Keys.Where(key =>
             key > curIdx + App.Settings.CacheSizeOneSideHqImages ||
             key < curIdx - App.Settings.CacheSizeOneSideHqImages).ToList();
-        keysToRemove.ForEach(delegate (int key)
+        keysToRemove.ForEach(delegate(int key)
         {
             _photos[key].Hq = null;
             _cachedHqImages.TryRemove(key, out _);
@@ -293,7 +293,7 @@ internal class PhotoDisplayController
         keysToRemove = _cachedPreviews.Keys.Where(key =>
             key > curIdx + App.Settings.CacheSizeOneSidePreviews ||
             key < curIdx - App.Settings.CacheSizeOneSidePreviews).ToList();
-        keysToRemove.ForEach(delegate (int key)
+        keysToRemove.ForEach(delegate(int key)
         {
             _photos[key].Preview = null;
             _cachedPreviews.TryRemove(key, out _);
@@ -311,9 +311,9 @@ internal class PhotoDisplayController
 
         _toBeCachedHqImages.Clear();
         var tempArray = (from cacheIdx in cacheIndexesHqImages
-                         where !_cachedHqImages.ContainsKey(cacheIdx) && !_hqsBeingCached.ContainsKey(cacheIdx) && cacheIdx >= 0 &&
-                               cacheIdx < _photos.Count
-                         select cacheIdx).ToArray();
+            where !_cachedHqImages.ContainsKey(cacheIdx) && !_hqsBeingCached.ContainsKey(cacheIdx) && cacheIdx >= 0 &&
+                  cacheIdx < _photos.Count
+            select cacheIdx).ToArray();
         if (tempArray.Length > 0) _toBeCachedHqImages.PushRange(tempArray);
 
         // Create new list of to be cached Previews.
@@ -329,9 +329,9 @@ internal class PhotoDisplayController
         _toBeCachedPreviews.Clear();
 
         tempArray = (from cacheIdx in cacheIndexesPreviews
-                     where !_cachedPreviews.ContainsKey(cacheIdx) && !_previewsBeingCached.ContainsKey(cacheIdx) &&
-                           cacheIdx >= 0 && cacheIdx < _photos.Count
-                     select cacheIdx).ToArray();
+            where !_cachedPreviews.ContainsKey(cacheIdx) && !_previewsBeingCached.ContainsKey(cacheIdx) &&
+                  cacheIdx >= 0 && cacheIdx < _photos.Count
+            select cacheIdx).ToArray();
         if (tempArray.Length > 0) _toBeCachedPreviews.PushRange(tempArray);
     }
 
@@ -355,18 +355,22 @@ internal class PhotoDisplayController
         });
     }
 
-    public async Task Copy()
+    public async Task CopyFileToClipboardAsync()
     {
-        string filePath = GetFullPathCurrentFile();
-
-        StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
-        IRandomAccessStream stream = await file.OpenAsync(FileAccessMode.Read);
-
-        DataPackage dataPackage = new DataPackage();
-        dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
-        dataPackage.SetStorageItems(new List<IStorageItem> { file });
-
-        Clipboard.SetContent(dataPackage);
+        try
+        {
+            string filePath = GetFullPathCurrentFile();
+            StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
+            IRandomAccessStream stream = await file.OpenAsync(FileAccessMode.Read);
+            DataPackage dataPackage = new DataPackage();
+            dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
+            dataPackage.SetStorageItems(new List<IStorageItem> { file });
+            Clipboard.SetContent(dataPackage);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex);
+        }
     }
 
     public void Fly(NavDirection direction)

--- a/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
+++ b/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
@@ -12,6 +12,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Devices.Display.Core;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
 
 namespace FlyPhotos.Controllers;
 
@@ -49,10 +52,10 @@ internal class PhotoDisplayController
     private readonly ConcurrentDictionary<int, bool> _previewsBeingCached = new();
 
     private readonly ConcurrentStack<int> _toBeDiskCachedPreviews = new();
-    private readonly ManualResetEvent _diskCachingCanStart = new (false);
+    private readonly ManualResetEvent _diskCachingCanStart = new(false);
 
     private int _keyPressCounter;
-    
+
 
     private readonly CanvasControl _d2dCanvas;
     private readonly Win2dCanvasController _canvasController;
@@ -122,7 +125,7 @@ internal class PhotoDisplayController
             }
             Photo.PhotosCount = files.Count;
 
-            foreach (var s in files) 
+            foreach (var s in files)
                 _photos.Add(new Photo(s));
 
 
@@ -137,7 +140,7 @@ internal class PhotoDisplayController
             var previewCachingThread = new Thread(PreviewCacheBuilderDoWork) { IsBackground = true };
             previewCachingThread.Start();
             var hqCachingThread = new Thread(HqImageCacheBuilderDoWork)
-                { IsBackground = true, Priority = ThreadPriority.AboveNormal };
+            { IsBackground = true, Priority = ThreadPriority.AboveNormal };
             hqCachingThread.Start();
             var previewDiskCachingThread = new Thread(PreviewDiskCacherDoWork) { IsBackground = true };
             previewDiskCachingThread.Start();
@@ -182,7 +185,7 @@ internal class PhotoDisplayController
                 _previewsBeingCached.Remove(index, out _);
 
                 if (photo.Preview.PreviewFrom == DisplayItem.PreviewSource.FromDisk) { _toBeDiskCachedPreviews.Push(item); }
-                
+
                 if (Photo.CurrentDisplayIndex == index)
                     UpgradeImageIfNeeded(photo, DisplayLevel.PlaceHolder, DisplayLevel.Preview);
 
@@ -250,8 +253,8 @@ internal class PhotoDisplayController
                 {
                     try
                     {
-                        if (_cachedPreviews.TryGetValue(index, out var image) && 
-                            image.Preview != null && 
+                        if (_cachedPreviews.TryGetValue(index, out var image) &&
+                            image.Preview != null &&
                             image.Preview.PreviewFrom == DisplayItem.PreviewSource.FromDisk)
                         {
                             PhotoDiskCacher.Instance.PutInCache(image.FileName, image.Preview.Bitmap);
@@ -281,7 +284,7 @@ internal class PhotoDisplayController
         var keysToRemove = _cachedHqImages.Keys.Where(key =>
             key > curIdx + App.Settings.CacheSizeOneSideHqImages ||
             key < curIdx - App.Settings.CacheSizeOneSideHqImages).ToList();
-        keysToRemove.ForEach(delegate(int key)
+        keysToRemove.ForEach(delegate (int key)
         {
             _photos[key].Hq = null;
             _cachedHqImages.TryRemove(key, out _);
@@ -290,7 +293,7 @@ internal class PhotoDisplayController
         keysToRemove = _cachedPreviews.Keys.Where(key =>
             key > curIdx + App.Settings.CacheSizeOneSidePreviews ||
             key < curIdx - App.Settings.CacheSizeOneSidePreviews).ToList();
-        keysToRemove.ForEach(delegate(int key)
+        keysToRemove.ForEach(delegate (int key)
         {
             _photos[key].Preview = null;
             _cachedPreviews.TryRemove(key, out _);
@@ -308,9 +311,9 @@ internal class PhotoDisplayController
 
         _toBeCachedHqImages.Clear();
         var tempArray = (from cacheIdx in cacheIndexesHqImages
-            where !_cachedHqImages.ContainsKey(cacheIdx) && !_hqsBeingCached.ContainsKey(cacheIdx) && cacheIdx >= 0 &&
-                  cacheIdx < _photos.Count
-            select cacheIdx).ToArray();
+                         where !_cachedHqImages.ContainsKey(cacheIdx) && !_hqsBeingCached.ContainsKey(cacheIdx) && cacheIdx >= 0 &&
+                               cacheIdx < _photos.Count
+                         select cacheIdx).ToArray();
         if (tempArray.Length > 0) _toBeCachedHqImages.PushRange(tempArray);
 
         // Create new list of to be cached Previews.
@@ -326,9 +329,9 @@ internal class PhotoDisplayController
         _toBeCachedPreviews.Clear();
 
         tempArray = (from cacheIdx in cacheIndexesPreviews
-            where !_cachedPreviews.ContainsKey(cacheIdx) && !_previewsBeingCached.ContainsKey(cacheIdx) &&
-                  cacheIdx >= 0 && cacheIdx < _photos.Count
-            select cacheIdx).ToArray();
+                     where !_cachedPreviews.ContainsKey(cacheIdx) && !_previewsBeingCached.ContainsKey(cacheIdx) &&
+                           cacheIdx >= 0 && cacheIdx < _photos.Count
+                     select cacheIdx).ToArray();
         if (tempArray.Length > 0) _toBeCachedPreviews.PushRange(tempArray);
     }
 
@@ -350,6 +353,20 @@ internal class PhotoDisplayController
         {
             _progressUpdateCallback(indexAndFileName, cacheProgressStatus);
         });
+    }
+
+    public async Task Copy()
+    {
+        string filePath = GetFullPathCurrentFile();
+
+        StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
+
+        IRandomAccessStream stream = await file.OpenAsync(FileAccessMode.Read);
+
+        DataPackage dataPackage = new DataPackage();
+        dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
+
+        Clipboard.SetContent(dataPackage);
     }
 
     public void Fly(NavDirection direction)

--- a/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
+++ b/Src/FlyPhotos/Controllers/PhotoDisplayController.cs
@@ -360,11 +360,11 @@ internal class PhotoDisplayController
         string filePath = GetFullPathCurrentFile();
 
         StorageFile file = await StorageFile.GetFileFromPathAsync(filePath);
-
         IRandomAccessStream stream = await file.OpenAsync(FileAccessMode.Read);
 
         DataPackage dataPackage = new DataPackage();
         dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
+        dataPackage.SetStorageItems(new List<IStorageItem> { file });
 
         Clipboard.SetContent(dataPackage);
     }

--- a/Src/FlyPhotos/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/Views/PhotoDisplayWindow.xaml.cs
@@ -218,17 +218,12 @@ public sealed partial class PhotoDisplayWindow : IBackGroundChangeable
     {
         try
         {
-            var ctrlState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
-
-            if (ctrlState.HasFlag(CoreVirtualKeyStates.Down) && e.Key == VirtualKey.C)
-            {
-                await _photoController.Copy();
-                e.Handled = true;
-                return;
-            }
-
             switch (e.Key)
             {
+                case VirtualKey.C when Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down):
+                    await _photoController.CopyFileToClipboardAsync();
+                    e.Handled = true;
+                    break;
                 case VirtualKey.Escape:
                     Close();
                     break;
@@ -319,33 +314,33 @@ public sealed partial class PhotoDisplayWindow : IBackGroundChangeable
         switch (backGround)
         {
             case "Transparent":
-                {
-                    SystemBackdrop = _transparentTintBackdrop;
-                    break;
-                }
+            {
+                SystemBackdrop = _transparentTintBackdrop;
+                break;
+            }
             case "Acrylic":
-                {
-                    SystemBackdrop = null;
-                    TrySetDesktopAcrylicBackdrop();
-                    break;
-                }
+            {
+                SystemBackdrop = null;
+                TrySetDesktopAcrylicBackdrop();
+                break;
+            }
             case "Mica":
-                {
-                    SystemBackdrop = null;
-                    TrySetMicaBackdrop(false);
-                    break;
-                }
+            {
+                SystemBackdrop = null;
+                TrySetMicaBackdrop(false);
+                break;
+            }
             case "Mica Alt":
-                {
-                    SystemBackdrop = null;
-                    TrySetMicaBackdrop(true);
-                    break;
-                }
+            {
+                SystemBackdrop = null;
+                TrySetMicaBackdrop(true);
+                break;
+            }
             case "Frozen":
-                {
-                    SystemBackdrop = _frozenBackdrop;
-                    break;
-                }
+            {
+                SystemBackdrop = _frozenBackdrop;
+                break;
+            }
         }
     }
 

--- a/Src/FlyPhotos/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/Views/PhotoDisplayWindow.xaml.cs
@@ -23,6 +23,10 @@ using static FlyPhotos.Controllers.PhotoDisplayController;
 using static Vanara.PInvoke.User32;
 using Icon = System.Drawing.Icon;
 using Window = Microsoft.UI.Xaml.Window;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using System.Threading.Tasks;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -83,7 +87,7 @@ public sealed partial class PhotoDisplayWindow : IBackGroundChangeable
         if (_photoController.IsSinglePhoto()) return;
         var delta = e.GetCurrentPoint(ButtonBack).Properties.MouseWheelDelta;
         if (delta > 0)
-        {            
+        {
             _photoController.Fly(NavDirection.Next);
             _repeatButtonReleaseCheckTimer.Start();
         }
@@ -210,10 +214,19 @@ public sealed partial class PhotoDisplayWindow : IBackGroundChangeable
         _photoController.LoadFirstPhoto();
     }
 
-    private void HandleKeyDown(object sender, KeyRoutedEventArgs e)
+    private async void HandleKeyDown(object sender, KeyRoutedEventArgs e)
     {
         try
         {
+            var ctrlState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+
+            if (ctrlState.HasFlag(CoreVirtualKeyStates.Down) && e.Key == VirtualKey.C)
+            {
+                await _photoController.Copy();
+                e.Handled = true;
+                return;
+            }
+
             switch (e.Key)
             {
                 case VirtualKey.Escape:
@@ -306,33 +319,33 @@ public sealed partial class PhotoDisplayWindow : IBackGroundChangeable
         switch (backGround)
         {
             case "Transparent":
-            {
-                SystemBackdrop = _transparentTintBackdrop;
-                break;
-            }
+                {
+                    SystemBackdrop = _transparentTintBackdrop;
+                    break;
+                }
             case "Acrylic":
-            {
-                SystemBackdrop = null;
-                TrySetDesktopAcrylicBackdrop();
-                break;
-            }
+                {
+                    SystemBackdrop = null;
+                    TrySetDesktopAcrylicBackdrop();
+                    break;
+                }
             case "Mica":
-            {
-                SystemBackdrop = null;
-                TrySetMicaBackdrop(false);
-                break;
-            }
+                {
+                    SystemBackdrop = null;
+                    TrySetMicaBackdrop(false);
+                    break;
+                }
             case "Mica Alt":
-            {
-                SystemBackdrop = null;
-                TrySetMicaBackdrop(true);
-                break;
-            }
+                {
+                    SystemBackdrop = null;
+                    TrySetMicaBackdrop(true);
+                    break;
+                }
             case "Frozen":
-            {
-                SystemBackdrop = _frozenBackdrop;
-                break;
-            }
+                {
+                    SystemBackdrop = _frozenBackdrop;
+                    break;
+                }
         }
     }
 


### PR DESCRIPTION
#28

Hi, I've decided to take matters into my own hands because it really is a crucial feature on my end since it is my main photo viewer now.

I get that the right-click is basically the context menu that we see in Windows' Explorer. That one seems like it'll take quite a bit more work to get a similar right-click ui and functionality similar to Windows' Photos so I didn't bother much.

What I did is I added `Ctrl + C` functionality when `PhotoDisplayWindow` is open to call a new async function in `PhotoDisplayController` to copy both the bitmap data and the file storage item in your clipboard data package. This way, image editors, which generally use the bitmap format will paste the image data, while file explorers can use the file reference. Some applications may prioritize one over the other based on the context, just like how Windows' Photos do it.