### PR TITLE
Live RAW re-decode on decoder setting change, with notification

### DIFF
--- a/Src/FlyPhotos/Core/Model/Enums.cs
+++ b/Src/FlyPhotos/Core/Model/Enums.cs
@@ -69,7 +69,8 @@ public enum Setting
     CtrlDragToMoveWindowToggle,
     AutoFadeToggle,
     AutoHideMouseToggle,
-    ImageScalingQualityChange
+    ImageScalingQualityChange,
+    RawDecodingChange
 }
 
 public enum ScrollDirection

--- a/Src/FlyPhotos/Core/Model/Photo.cs
+++ b/Src/FlyPhotos/Core/Model/Photo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FlyPhotos.Display.ImageReading;
+using FlyPhotos.Services;
 using Microsoft.Graphics.Canvas;
 using Windows.Foundation;
 
@@ -20,12 +21,15 @@ internal partial class Photo : IDisposable
 
     public bool IsVector { get; }
 
+    public bool IsRaw { get; }
+
     public Photo(string selectedFilePath)
     {
         FilePath = selectedFilePath;
         string extension = Path.GetExtension(FilePath);
         SupportsTransparency = !string.IsNullOrEmpty(extension) && FormatsSupportingTransparency.Contains(extension);
         IsVector = extension.Contains(".svg", StringComparison.OrdinalIgnoreCase);
+        IsRaw = !string.IsNullOrEmpty(extension) && CodecDiscovery.IsRawFile(extension);
     }
 
     private static readonly Photo _empty = new(string.Empty);

--- a/Src/FlyPhotos/Display/Controllers/PhotoDisplayController.cs
+++ b/Src/FlyPhotos/Display/Controllers/PhotoDisplayController.cs
@@ -290,6 +290,28 @@ internal partial class PhotoDisplayController
         UpdateFileNameAndDetails();
     }
 
+    // --- RAW decode settings changed ---
+
+    // Drops cached RAW HQ bitmaps so the new decoder settings take effect, and re-decodes them.
+    // Called from the UI thread when a RAW decode setting (DecodeRawData / decoder priority) changes.
+    public async Task InvalidateRawHqCache()
+    {
+        var currentKey = _photoSessionState.CurrentPhotoKey;
+        var currentPhoto = _photoList.GetPhoto(currentKey);
+
+        // If a RAW HQ bitmap we're about to dispose is on screen, step the display down first so the
+        // renderer isn't holding a disposed CanvasBitmap. OnHqReady upgrades it back once re-decoded.
+        if (currentPhoto is { IsRaw: true } &&
+            _photoSessionState.CurrentDisplayLevel == DisplayLevel.Hq)
+        {
+            var level = _cache.IsPreviewLoaded(currentKey)
+                ? DisplayLevel.Preview : DisplayLevel.PlaceHolder;
+            await SetSourceAsync(currentPhoto, level);
+        }
+
+        _cache.InvalidateHqForRawFiles();
+    }
+
     // --- Deletion ---
 
     public bool CanDeleteCurrentPhoto()

--- a/Src/FlyPhotos/Display/Controllers/PhotoDisplayController.cs
+++ b/Src/FlyPhotos/Display/Controllers/PhotoDisplayController.cs
@@ -384,6 +384,10 @@ internal partial class PhotoDisplayController
 
     public string GetFullPathCurrentFile() => _photoList[_photoSessionState.CurrentPhotoKey].FilePath;
 
+    /// <summary>Whether the on-screen photo is a RAW file. Lock-free read; safe to call cross-thread.</summary>
+    public bool CurrentPhotoIsRaw =>
+        _photoList.GetPhoto(_photoSessionState.CurrentPhotoKey) is { IsRaw: true };
+
     // --- Cleanup ---
 
     public void Dispose()

--- a/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
+++ b/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
@@ -52,6 +52,10 @@ internal sealed class PrefetchCache : IDisposable
     // Reused across SyncCacheTier calls — only touched on the UI/STA thread (inside MoveWindow).
     private readonly HashSet<int> _syncKeysToKeep = new();
 
+    // Bumped (on the UI/STA thread) whenever RAW decode settings change so any RAW HQ decode that was
+    // already in flight is discarded on completion instead of committing a stale bitmap.
+    private volatile int _hqGeneration;
+
     // Resolves a key to its Photo (or null). Read-only access into the controller's PhotoList; the
     // controller owns the collection and disposal timing.
     private readonly Func<int, Photo?> _getPhoto;
@@ -151,6 +155,26 @@ internal sealed class PrefetchCache : IDisposable
 
     public bool IsHqLoaded(int key)      => _hqTier.Done.ContainsKey(key);
     public bool IsPreviewLoaded(int key) => _previewTier.Done.ContainsKey(key);
+
+    /// <summary>
+    /// Drop every cached RAW-file HQ bitmap so the new decoder settings take effect, and bump the
+    /// generation so any in-flight RAW decode is discarded on completion. Requeues the in-window keys
+    /// via <see cref="MoveWindow"/>. Called on the UI/STA thread.
+    /// </summary>
+    public void InvalidateHqForRawFiles()
+    {
+        _hqGeneration++;
+
+        foreach (int key in _hqTier.Done.Keys)
+            if (_getPhoto(key) is { IsRaw: true } photo)
+            {
+                photo.DisposeHqOnly();
+                _hqTier.Done.TryRemove(key, out _);
+            }
+
+        // Reuse the window sync to requeue the in-window keys we just dropped.
+        MoveWindow(_windowCentre, _windowKeys, signalHqLoading: true);
+    }
 
     // -------------------------------------------------------------------------
     // Worker threads
@@ -254,8 +278,24 @@ internal sealed class PrefetchCache : IDisposable
         try
         {
             _hqTier.InFlight[key] = 0;
+            int gen = _hqGeneration;
             if (_getPhoto(key) is not { } photo) return;
             await photo.LoadHq(_device);
+
+            // RAW decode settings changed mid-flight: this bitmap used the old settings.
+            // Discard it and requeue if the key is still in the HQ window.
+            if (gen != _hqGeneration && photo.IsRaw)
+            {
+                photo.DisposeHqOnly();
+                _hqTier.InFlight.Remove(key, out _);
+                if (IsInDesiredHqWindow(key))
+                {
+                    _hqTier.Queue.Push(key);
+                    _hqTier.Signal.Set();
+                }
+                return;
+            }
+
             _hqTier.Done[key] = 0;
             _hqTier.InFlight.Remove(key, out _);
             HqReady?.Invoke(key);
@@ -300,6 +340,12 @@ internal sealed class PrefetchCache : IDisposable
         foreach (int key in desiredKeys)
             if (!tier.Done.ContainsKey(key) && !tier.InFlight.ContainsKey(key))
                 tier.Queue.Push(key);
+    }
+
+    private bool IsInDesiredHqWindow(int key)
+    {
+        if (_windowKeys.Count == 0 || _windowCentre < 0) return false;
+        return FindNeighborKeys(_windowCentre, AppConfig.Settings.CacheSizeOneSideHqImages).Contains(key);
     }
 
     private List<int> FindNeighborKeys(int currentPosition, int cacheSizeOneSide)

--- a/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
+++ b/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
@@ -281,26 +281,31 @@ internal sealed class PrefetchCache : IDisposable
             int gen = _hqGeneration;
             if (_getPhoto(key) is not { } photo) return;
             await photo.LoadHq(_device);
-
-            // RAW decode settings changed mid-flight: this bitmap used the old settings.
-            // Discard it and requeue if the key is still in the HQ window.
-            if (gen != _hqGeneration && photo.IsRaw)
-            {
-                photo.DisposeHqOnly();
-                _hqTier.InFlight.Remove(key, out _);
-                if (IsInDesiredHqWindow(key))
-                {
-                    _hqTier.Queue.Push(key);
-                    _hqTier.Signal.Set();
-                }
-                return;
-            }
-
+            if (DiscardedStaleRawDecode(key, photo, gen)) return;
             _hqTier.Done[key] = 0;
             _hqTier.InFlight.Remove(key, out _);
             HqReady?.Invoke(key);
         }
         finally { _hqThrottler.Release(); }
+    }
+
+    /// <summary>
+    /// If RAW decode settings changed while this RAW HQ decode was in flight, the bitmap used the old
+    /// settings. Discards it (and requeues the key if still in the HQ window) and returns true, so the
+    /// caller skips committing the stale result. Returns false for the normal case.
+    /// </summary>
+    private bool DiscardedStaleRawDecode(int key, Photo photo, int gen)
+    {
+        if (gen == _hqGeneration || !photo.IsRaw) return false;
+
+        photo.DisposeHqOnly();
+        _hqTier.InFlight.Remove(key, out _);
+        if (IsInDesiredHqWindow(key))
+        {
+            _hqTier.Queue.Push(key);
+            _hqTier.Signal.Set();
+        }
+        return true;
     }
 
     private async Task DiskCachePreviewAsync(int key)

--- a/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
+++ b/Src/FlyPhotos/Display/Controllers/PrefetchCache.cs
@@ -347,10 +347,20 @@ internal sealed class PrefetchCache : IDisposable
                 tier.Queue.Push(key);
     }
 
+    // Membership test for the HQ window. Called from a ThreadPool thread (the stale-RAW-decode discard
+    // path), so it snapshots the copy-on-write key list and centre once and scans only that snapshot —
+    // never re-reading the shared fields or indexing a list that may have been swapped underneath it.
     private bool IsInDesiredHqWindow(int key)
     {
-        if (_windowKeys.Count == 0 || _windowCentre < 0) return false;
-        return FindNeighborKeys(_windowCentre, AppConfig.Settings.CacheSizeOneSideHqImages).Contains(key);
+        var keys = _windowKeys;
+        int centre = _windowCentre;
+        if (centre < 0 || centre >= keys.Count) return false;
+        int side = AppConfig.Settings.CacheSizeOneSideHqImages;
+        int lo = Math.Max(0, centre - side);
+        int hi = Math.Min(keys.Count - 1, centre + side);
+        for (int pos = lo; pos <= hi; pos++)
+            if (keys[pos] == key) return true;
+        return false;
     }
 
     private List<int> FindNeighborKeys(int currentPosition, int cacheSizeOneSide)

--- a/Src/FlyPhotos/Services/CodecDiscovery.cs
+++ b/Src/FlyPhotos/Services/CodecDiscovery.cs
@@ -135,6 +135,9 @@ internal static class CodecDiscovery
 
     public static bool IsRawlerRaw(string extension) => _rawlerRawExtensions.Contains(extension);
 
+    public static bool IsRawFile(string extension) =>
+        IsRawlerRaw(extension) || IsWicRaw(extension) || IsMagickRaw(extension);
+
     public static IReadOnlyList<CodecInfo> GetAllCodecs()
     {
         return _codecInfoList;

--- a/Src/FlyPhotos/Strings/ar-SA/Resources.resw
+++ b/Src/FlyPhotos/Strings/ar-SA/Resources.resw
@@ -342,6 +342,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>المساهمون</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>ستتم إعادة تحميل الصورة الحالية خلال لحظات.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>تم تغيير فك الترميز</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>استخدام بيانات RAW الفعلية بدلاً من JPEG المضمنة داخل ملف RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/de-DE/Resources.resw
+++ b/Src/FlyPhotos/Strings/de-DE/Resources.resw
@@ -342,6 +342,12 @@ Einstellungen &gt; Apps &gt; Standard-Apps.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Danksagung</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Das aktuelle Foto wird gleich neu geladen.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decoder geändert</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Verwenden Sie echte RAW-Daten anstelle des eingebetteten JPEGs in der RAW-Datei</value>
   </data>

--- a/Src/FlyPhotos/Strings/en-US/Resources.resw
+++ b/Src/FlyPhotos/Strings/en-US/Resources.resw
@@ -342,6 +342,12 @@ Settings &gt; Apps &gt; Default apps.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Credits</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>The current photo will reload in a moment.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decoder Changed</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Use actual RAW data instead of the embedded JPEG inside the RAW file.</value>
   </data>

--- a/Src/FlyPhotos/Strings/es-ES/Resources.resw
+++ b/Src/FlyPhotos/Strings/es-ES/Resources.resw
@@ -342,6 +342,12 @@ Configuración &gt; Aplicaciones &gt; Aplicaciones predeterminadas.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Créditos</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>La foto actual se recargará en un momento.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decodificador cambiado</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Usar datos RAW reales en lugar del JPEG incrustado dentro del archivo RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/fi-FI/Resources.resw
+++ b/Src/FlyPhotos/Strings/fi-FI/Resources.resw
@@ -342,6 +342,12 @@ Asetukset &gt; Sovellukset &gt; Oletussovellukset.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Kiitokset</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Nykyinen kuva ladataan uudelleen hetken kuluttua.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Dekooderi vaihdettu</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Käytä todellisia RAW-tietoja RAW-tiedoston sisällä olevan upotetun JPEG-kuvan sijaan.</value>
   </data>

--- a/Src/FlyPhotos/Strings/fr-FR/Resources.resw
+++ b/Src/FlyPhotos/Strings/fr-FR/Resources.resw
@@ -342,6 +342,12 @@ Paramètres &gt; Applications &gt; Applications par défaut.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Crédits</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>La photo actuelle sera rechargée dans un instant.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Décodeur modifié</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Utiliser les données RAW réelles au lieu du JPEG intégré dans le fichier RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/hu-HU/Resources.resw
+++ b/Src/FlyPhotos/Strings/hu-HU/Resources.resw
@@ -341,6 +341,12 @@ Válassza ki a FlyPhotos-t, és válassza a Mindig lehetőséget.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Köszönetnyilvánítás</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Az aktuális fénykép hamarosan újratöltődik.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Dekódoló megváltozott</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Tényleges RAW adatok használata a RAW fájlba ágyazott JPEG helyett.</value>
   </data>

--- a/Src/FlyPhotos/Strings/it-IT/Resources.resw
+++ b/Src/FlyPhotos/Strings/it-IT/Resources.resw
@@ -342,6 +342,12 @@ Impostazioni &gt; App &gt; App predefinite.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Crediti</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>La foto corrente verrà ricaricata tra un momento.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decoder cambiato</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Usa i dati RAW reali invece del JPEG incorporato nel file RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/ja-JP/Resources.resw
+++ b/Src/FlyPhotos/Strings/ja-JP/Resources.resw
@@ -341,6 +341,12 @@ FlyPhotosを選択し、「常に」をクリックします。</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>著作権情報</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>現在の写真はまもなく再読み込みされます。</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>デコーダーを変更しました</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>RAWファイル内の埋め込みJPEGの代わりに実際のRAWデータを使用します</value>
   </data>

--- a/Src/FlyPhotos/Strings/ko-KR/Resources.resw
+++ b/Src/FlyPhotos/Strings/ko-KR/Resources.resw
@@ -341,6 +341,12 @@ FlyPhotos를 선택하고 항상 선택을 선택합니다.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>크레딧</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>현재 사진이 잠시 후 다시 로드됩니다.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>디코더 변경됨</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>RAW 파일 내에 포함된 JPEG 대신 실제 RAW 데이터를 사용합니다</value>
   </data>

--- a/Src/FlyPhotos/Strings/ml-IN/Resources.resw
+++ b/Src/FlyPhotos/Strings/ml-IN/Resources.resw
@@ -339,6 +339,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>കടപ്പാടുകൾ</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>നിലവിലെ ഫോട്ടോ ഉടൻ വീണ്ടും ലോഡ് ചെയ്യും.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>ഡീകോഡർ മാറ്റി</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>RAW ഫയലിനുള്ളിലെ എംബെഡഡ് JPEG നു പകരം യഥാർത്ഥ RAW ഡാറ്റ ഉപയോഗിക്കുക</value>
   </data>

--- a/Src/FlyPhotos/Strings/nl-NL/Resources.resw
+++ b/Src/FlyPhotos/Strings/nl-NL/Resources.resw
@@ -342,6 +342,12 @@ Instellingen &gt; Apps &gt; Standaard-apps.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Erkenningen</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>De huidige foto wordt zo opnieuw geladen.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decoder gewijzigd</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Gebruik echte RAW-gegevens in plaats van de ingesloten JPEG in het RAW-bestand</value>
   </data>

--- a/Src/FlyPhotos/Strings/pl-PL/Resources.resw
+++ b/Src/FlyPhotos/Strings/pl-PL/Resources.resw
@@ -342,6 +342,12 @@ w Ustawieniach &gt; Aplikacje &gt; Aplikacje domyślne.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Kredyty</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Bieżące zdjęcie zostanie za chwilę załadowane ponownie.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Zmieniono dekoder</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Użyj rzeczywistych danych RAW zamiast osadzonego pliku JPEG w pliku RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/pt-BR/Resources.resw
+++ b/Src/FlyPhotos/Strings/pt-BR/Resources.resw
@@ -342,6 +342,12 @@ Configurações &gt; Aplicativos &gt; Aplicativos padrão.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Créditos</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>A foto atual será recarregada em instantes.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Decodificador alterado</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Usar os dados RAW reais em vez do JPEG incorporado no arquivo RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/pt-PT/Resources.resw
+++ b/Src/FlyPhotos/Strings/pt-PT/Resources.resw
@@ -342,6 +342,12 @@ Definições &gt; Aplicações &gt; Aplicações predefinidas.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Créditos</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>A fotografia atual será recarregada dentro de momentos.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Descodificador alterado</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Utilizar dados RAW reais em vez do JPEG incorporado no ficheiro RAW.</value>
   </data>

--- a/Src/FlyPhotos/Strings/ru-RU/Resources.resw
+++ b/Src/FlyPhotos/Strings/ru-RU/Resources.resw
@@ -342,6 +342,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Благодарности</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Текущее фото будет перезагружено через мгновение.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Декодер изменён</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Использовать реальные данные RAW вместо встроенного JPEG внутри RAW-файла</value>
   </data>

--- a/Src/FlyPhotos/Strings/sv-SE/Resources.resw
+++ b/Src/FlyPhotos/Strings/sv-SE/Resources.resw
@@ -342,6 +342,12 @@ Inställningar &gt; Appar &gt; Standardappar.</value>
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Bidrag</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Det aktuella fotot laddas snart om.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Avkodare ändrad</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Använd faktisk RAW-data istället för den inbäddade JPEG-bilden i RAW-filen.</value>
   </data>

--- a/Src/FlyPhotos/Strings/uk-UA/Resources.resw
+++ b/Src/FlyPhotos/Strings/uk-UA/Resources.resw
@@ -342,6 +342,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>Подяки</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>Поточне фото буде перезавантажено за мить.</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>Декодер змінено</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>Використовувати справжні RAW-дані замість вбудованого JPEG у RAW-файлі.</value>
   </data>

--- a/Src/FlyPhotos/Strings/zh-CN/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-CN/Resources.resw
@@ -342,6 +342,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>致谢</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>当前照片稍后将重新加载。</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>解码器已更改</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>使用实际 RAW 数据，而不是 RAW 文件中内嵌的 JPEG。</value>
   </data>

--- a/Src/FlyPhotos/Strings/zh-TW/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-TW/Resources.resw
@@ -342,6 +342,12 @@
   <data name="SettingsCardCredits.Header" xml:space="preserve">
     <value>致謝</value>
   </data>
+  <data name="RawDecodeTeachingTip.Subtitle" xml:space="preserve">
+    <value>目前的相片將在稍後重新載入。</value>
+  </data>
+  <data name="RawDecodeTeachingTip.Title" xml:space="preserve">
+    <value>解碼器已變更</value>
+  </data>
   <data name="SettingsCardDecodeRawData.Description" xml:space="preserve">
     <value>使用實際 RAW 資料，而不是 RAW 檔案內嵌的 JPEG</value>
   </data>

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
@@ -391,6 +391,7 @@ public sealed partial class PhotoDisplayWindow
             _settingWindow.Closed += SettingWindow_Closed;
             _settingWindow.Activate();
             _settingWindow.SettingChanged += SettingWindow_SettingChanged;
+            _settingWindow.IsCurrentPhotoRaw = () => _photoController.CurrentPhotoIsRaw;
         }
         else
         {

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
@@ -771,6 +771,9 @@ public sealed partial class PhotoDisplayWindow
             case Setting.ImageScalingQualityChange:
                 _canvasController.HandleImageScalingQualityChange();
                 break;
+            case Setting.RawDecodingChange:
+                _ = _photoController.InvalidateRawHqCache();
+                break;
             case Setting.Theme:
                 _windAppearanceManager.SetWindowTheme(AppConfig.Settings.Theme);
                 break;

--- a/Src/FlyPhotos/UI/Views/Settings.xaml
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml
@@ -566,6 +566,11 @@
                             </controls:SettingsExpander.Items>
                         </controls:SettingsExpander>
 
+                        <TeachingTip
+                            x:Name="RawDecodeTeachingTip"
+                            x:Uid="RawDecodeTeachingTip"
+                            IsLightDismissEnabled="True" />
+
                         <controls:SettingsCard
                             x:Name="SettingsCardAllowMultiInstance"
                             x:Uid="SettingsCardAllowMultiInstance"

--- a/Src/FlyPhotos/UI/Views/Settings.xaml
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml
@@ -530,6 +530,7 @@
                                         Width="Auto"
                                         HorizontalAlignment="Left"
                                         AllowDrop="True"
+                                        IsEnabled="{x:Bind ButtonDecodeRawData.IsOn, Mode=OneWay}"
                                         Background="{ThemeResource LayerFillColorDefaultBrush}"
                                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                         BorderThickness="1"

--- a/Src/FlyPhotos/UI/Views/Settings.xaml
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml
@@ -128,6 +128,7 @@
                             x:Name="SettingsCardWindowLaunchMode"
                             x:Uid="SettingsCardWindowLaunchMode"
                             Margin="0,5,0,0"
+                            Description="{x:Bind LaunchModeDescription(ComboWindowLaunchMode.SelectedIndex), Mode=OneWay}"
                             HeaderIcon="{ui:FontIcon Glyph=&#xEC77;}">
                             <ComboBox
                                 x:Name="ComboWindowLaunchMode"

--- a/Src/FlyPhotos/UI/Views/Settings.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml.cs
@@ -38,6 +38,9 @@ internal sealed partial class Settings
 {
     public event Action<Setting>? SettingChanged;
 
+    /// <summary>Set by the owner so the RAW handlers can tell whether the on-screen photo is RAW.</summary>
+    public Func<bool>? IsCurrentPhotoRaw { get; set; }
+
     private readonly List<LanguageInfo> _supportedLanguages = [];
 
     private readonly WindowAppearanceManager _windAppearanceManager;
@@ -166,6 +169,7 @@ internal sealed partial class Settings
     {
         await AppConfig.SaveAsync();
         SettingChanged?.Invoke(Setting.RawDecodingChange);
+        NotifyRawDecodeChangeIfViewingRaw(PriorityListView);
     }
 
     private async void ButtonEnableExternalShortcut_OnToggled(object sender, RoutedEventArgs e)
@@ -206,6 +210,19 @@ internal sealed partial class Settings
         AppConfig.Settings.DecodeRawData = ButtonDecodeRawData.IsOn;
         await AppConfig.SaveAsync();
         SettingChanged?.Invoke(Setting.RawDecodingChange);
+        NotifyRawDecodeChangeIfViewingRaw(ButtonDecodeRawData);
+    }
+
+    // Point the shared teaching tip at the control the user just changed and show it, but only when the
+    // on-screen photo is a RAW file, so the user learns the change will re-decode the current image
+    // shortly. Re-target then reopen so it repositions even if it was already showing (a drag reorder
+    // fires CollectionChanged several times).
+    private void NotifyRawDecodeChangeIfViewingRaw(FrameworkElement target)
+    {
+        if (IsCurrentPhotoRaw?.Invoke() != true) return;
+        RawDecodeTeachingTip.IsOpen = false;
+        RawDecodeTeachingTip.Target = target;
+        RawDecodeTeachingTip.IsOpen = true;
     }
 
     private async void ButtonEnableAutoHideMouse_OnToggled(object sender, RoutedEventArgs e)

--- a/Src/FlyPhotos/UI/Views/Settings.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml.cs
@@ -165,6 +165,7 @@ internal sealed partial class Settings
     private async void RawDecoderPriority_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         await AppConfig.SaveAsync();
+        SettingChanged?.Invoke(Setting.RawDecodingChange);
     }
 
     private async void ButtonEnableExternalShortcut_OnToggled(object sender, RoutedEventArgs e)
@@ -204,6 +205,7 @@ internal sealed partial class Settings
     {
         AppConfig.Settings.DecodeRawData = ButtonDecodeRawData.IsOn;
         await AppConfig.SaveAsync();
+        SettingChanged?.Invoke(Setting.RawDecodingChange);
     }
 
     private async void ButtonEnableAutoHideMouse_OnToggled(object sender, RoutedEventArgs e)

--- a/Src/FlyPhotos/UI/Views/Settings.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml.cs
@@ -99,7 +99,6 @@ internal sealed partial class Settings
         RectThumbnailSelection.Stroke = new SolidColorBrush(ColorConverter.FromHex(AppConfig.Settings.ThumbnailSelectionColor));
         SliderThumbnailSize.Value = AppConfig.Settings.ThumbnailSize;
         ComboWindowLaunchMode.SelectedIndex = GetIndexForWindowLaunchMode(AppConfig.Settings.WindowLaunchMode);
-        SettingsCardWindowLaunchMode.Description = ComboWindowLaunchMode.SelectedIndex == 2 ? L.Get("SettingsCardWindowLaunchMode/Description") : String.Empty;
         ButtonAllowMultiInstance.IsOn = AppConfig.Settings.AllowMultiInstance;
         ButtonConfirmBeforeDelete.IsOn = AppConfig.Settings.ConfirmForDelete;
         ButtonShowFileName.IsOn = AppConfig.Settings.ShowFileName;
@@ -292,7 +291,6 @@ internal sealed partial class Settings
     private async void ComboWindowLaunchMode_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         AppConfig.Settings.WindowLaunchMode = GetWindowLaunchModeForIndex(ComboWindowLaunchMode.SelectedIndex);
-        SettingsCardWindowLaunchMode.Description = ComboWindowLaunchMode.SelectedIndex == 2 ? L.Get("SettingsCardWindowLaunchMode/Description") : String.Empty;
         await AppConfig.SaveAsync();
     }
 
@@ -465,6 +463,9 @@ internal sealed partial class Settings
     {
         return index == 0;
     }
+
+    // Show the "Previous state" explanation only for the LastWindowState option (index 2).
+    private string LaunchModeDescription(int index) => index == 2 ? L.Get("SettingsCardWindowLaunchMode/Description") : string.Empty;
 
     // Mapping helpers to use index-based combo box handling while keeping AppSettings stored as enum names
     private static int GetIndexForTheme(ElementTheme theme)

--- a/Src/FlyPhotos/UI/Views/Settings.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/Settings.xaml.cs
@@ -167,6 +167,8 @@ internal sealed partial class Settings
 
     private async void RawDecoderPriority_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
+        // A ListView reorder raises twice (Remove + Add). Handle only the Add part so the save/notify runs once.
+        if (e.Action != System.Collections.Specialized.NotifyCollectionChangedAction.Add) return;
         await AppConfig.SaveAsync();
         SettingChanged?.Invoke(Setting.RawDecodingChange);
         NotifyRawDecodeChangeIfViewingRaw(PriorityListView);


### PR DESCRIPTION
Changing the **Decode RAW data** toggle or **RAW decoder priority** now takes
effect immediately on already-decoded images, instead of only applying to
photos loaded afterward. Ref #186

- **Live re-decode:** cached HQ RAW bitmaps are dropped and re-decoded on a
  setting change; in-flight decodes started under the old settings are
  discarded and requeued (generation counter). Non-RAW images are untouched.
- **Notification:** a localized TeachingTip pinned to the changed control tells
  the user the on-screen RAW photo will reload — only shown when a RAW photo is
  displayed. Settings stays decoupled via an `IsCurrentPhotoRaw` hook.
- **UX polish:** priority list disabled when RAW decoding is off; drag-reorder
  fires the change once; launch-mode description bound instead of set imperatively.
- **Localization:** title/subtitle strings for all 20 locales, matching each
  locale's existing "decoder"/"photo" vocabulary.

**Testing:** toggle/reorder while viewing a cached RAW → image re-decodes and
tip shows; neighbouring cached RAW shows new output; rapid toggling mid-decode
doesn't crash; non-RAW files don't flicker.