### PR TITLE
Add EXIF metadata info panel

### DIFF
--- a/Src/FlyPhotos/Core/Model/ExifData.cs
+++ b/Src/FlyPhotos/Core/Model/ExifData.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace FlyPhotos.Core.Model;
 
-public readonly record struct ExifField(string Label, string Value);
+public readonly record struct ExifField(string Label, string Value, Uri? LinkUrl = null);
 
 public sealed record ExifFieldGroup(string Category, IReadOnlyList<ExifField> Fields);
 

--- a/Src/FlyPhotos/Core/Model/ExifData.cs
+++ b/Src/FlyPhotos/Core/Model/ExifData.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace FlyPhotos.Core.Model;
+
+public readonly record struct ExifField(string Label, string Value);
+
+public sealed record ExifFieldGroup(string Category, IReadOnlyList<ExifField> Fields);
+
+public sealed record ExifData(IReadOnlyList<ExifField> Summary, Lazy<IReadOnlyList<ExifFieldGroup>> All)
+{
+    public static readonly ExifData Empty = new([], new Lazy<IReadOnlyList<ExifFieldGroup>>(() => []));
+}

--- a/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
+++ b/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -39,7 +40,7 @@ public static class ExifReader
         }
     }
 
-    private static IReadOnlyList<ExifField> BuildSummary(string filePath, IReadOnlyList<MetadataExtractor.Directory> directories)
+    private static List<ExifField> BuildSummary(string filePath, IReadOnlyList<MetadataExtractor.Directory> directories)
     {
         var ifd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
         var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
@@ -48,27 +49,45 @@ public static class ExifReader
 
         var fields = new List<ExifField>();
         AddField(fields, L.Get("Exif_FileName"), fileInfo.Name);
-        AddField(fields, L.Get("Exif_FileSize"), $"{fileInfo.Length / 1024.0:F1} KB");
-        AddField(fields, L.Get("Exif_DateTaken"), subIfd?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal));
+        AddField(fields, L.Get("Exif_FileSize"), FormatFileSize(fileInfo.Length));
+        AddField(fields, L.Get("Exif_Dimensions"), GetDimensions(subIfd));
         AddField(fields, L.Get("Exif_CameraMake"), ifd0?.GetDescription(ExifDirectoryBase.TagMake));
         AddField(fields, L.Get("Exif_CameraModel"), ifd0?.GetDescription(ExifDirectoryBase.TagModel));
+        AddField(fields, L.Get("Exif_DateTaken"), FormatExifDate(subIfd?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal)));
         AddField(fields, L.Get("Exif_LensModel"), subIfd?.GetDescription(ExifDirectoryBase.TagLensModel));
         AddField(fields, L.Get("Exif_FocalLength"), subIfd?.GetDescription(ExifDirectoryBase.TagFocalLength));
         AddField(fields, L.Get("Exif_Aperture"), subIfd?.GetDescription(ExifDirectoryBase.TagFNumber));
-        AddField(fields, L.Get("Exif_ShutterSpeed"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureTime));
+        AddField(fields, L.Get("Exif_ShutterSpeed"), GetShutterSpeed(subIfd));
         AddField(fields, L.Get("Exif_Iso"), subIfd?.GetDescription(ExifDirectoryBase.TagIsoEquivalent));
         AddField(fields, L.Get("Exif_ExposureBias"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureBias));
         AddField(fields, L.Get("Exif_MeteringMode"), subIfd?.GetDescription(ExifDirectoryBase.TagMeteringMode));
         AddField(fields, L.Get("Exif_ExposureProgram"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureProgram));
         AddField(fields, L.Get("Exif_Flash"), subIfd?.GetDescription(ExifDirectoryBase.TagFlash));
-        AddField(fields, L.Get("Exif_Dimensions"), GetDimensions(subIfd));
         AddField(fields, L.Get("Exif_Orientation"), ifd0?.GetDescription(ExifDirectoryBase.TagOrientation));
         AddField(fields, L.Get("Exif_ColorSpace"), subIfd?.GetDescription(ExifDirectoryBase.TagColorSpace));
-        AddField(fields, L.Get("Exif_GpsLocation"), GetGpsLocation(gps));
+        AddGpsField(fields, gps);
         return fields;
     }
 
-    private static IReadOnlyList<ExifFieldGroup> BuildAll(IReadOnlyList<MetadataExtractor.Directory> directories)
+    private static string FormatFileSize(long bytes)
+    {
+        const double kb = 1024;
+        const double mb = kb * 1024;
+        const double gb = mb * 1024;
+        if (bytes >= gb) return $"{bytes / gb:F1} GB";
+        return bytes >= mb ? $"{bytes / mb:F1} MB" : $"{bytes / kb:F1} KB";
+    }
+
+    // EXIF stores dates as "yyyy:MM:dd HH:mm:ss" (colons in the date part per spec);
+    // rewrite to "yyyy-MM-dd HH:mm:ss" for readability.
+    private static string? FormatExifDate(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return raw;
+        var parts = raw.Split(' ', 2);
+        return parts.Length == 2 ? $"{parts[0].Replace(':', '-')} {parts[1]}" : raw;
+    }
+
+    private static List<ExifFieldGroup> BuildAll(IReadOnlyList<MetadataExtractor.Directory> directories)
     {
         var groups = new List<ExifFieldGroup>();
         foreach (var directory in directories)
@@ -84,16 +103,50 @@ public static class ExifReader
 
     private static string? GetDimensions(ExifSubIfdDirectory? subIfd)
     {
-        var width = subIfd?.GetDescription(ExifDirectoryBase.TagExifImageWidth);
-        var height = subIfd?.GetDescription(ExifDirectoryBase.TagExifImageHeight);
-        return width != null && height != null ? $"{width} x {height}" : null;
+        // Use the raw pixel counts rather than GetDescription(), which appends
+        // a " pixels" unit suffix to each value (e.g. "5472 pixels x 3648 pixels").
+        if (subIfd == null) return null;
+        if (!subIfd.TryGetInt32(ExifDirectoryBase.TagExifImageWidth, out var width)) return null;
+        if (!subIfd.TryGetInt32(ExifDirectoryBase.TagExifImageHeight, out var height)) return null;
+        return $"{width} × {height}";
     }
 
-    private static string? GetGpsLocation(GpsDirectory? gps)
+    // GetDescription() for this tag just echoes the raw EXIF rational (e.g. "19983/1000000 sec")
+    // instead of the conventional "1/N sec" notation most viewers show, since many cameras store
+    // exposure time as an unreduced fraction rather than a clean 1/N value. Fall back to the raw
+    // description for degenerate values (e.g. a bulb-mode 0/1 sentinel) instead of hiding the field.
+    private static string? GetShutterSpeed(ExifSubIfdDirectory? subIfd)
     {
-        var latitude = gps?.GetDescription(GpsDirectory.TagLatitude);
-        var longitude = gps?.GetDescription(GpsDirectory.TagLongitude);
-        return latitude != null && longitude != null ? $"{latitude}, {longitude}" : null;
+        if (subIfd == null) return null;
+        if (subIfd.TryGetDouble(ExifDirectoryBase.TagExposureTime, out var seconds) && seconds > 0)
+        {
+            return seconds < 1
+                ? $"1/{Math.Round(1.0 / seconds)} s"
+                : $"{seconds:0.##} s";
+        }
+        return subIfd.GetDescription(ExifDirectoryBase.TagExposureTime);
+    }
+
+    private static void AddGpsField(List<ExifField> fields, GpsDirectory? gps)
+    {
+        if (gps == null) return;
+
+        if (gps.GetGeoLocation() is { IsZero: false } location)
+        {
+            var lat = location.Latitude.ToString(CultureInfo.InvariantCulture);
+            var lon = location.Longitude.ToString(CultureInfo.InvariantCulture);
+            var mapsUrl = new Uri($"https://www.google.com/maps/search/?api=1&query={lat},{lon}");
+            fields.Add(new ExifField(L.Get("Exif_GpsLocation"), location.ToDmsString(), mapsUrl));
+            return;
+        }
+
+        // GetGeoLocation() needs both the coordinate and its N/S/E/W ref tag to resolve; fall back
+        // to the raw per-tag descriptions so a file missing/malformed only in the ref tag still
+        // shows something, just without a map link.
+        var latDesc = gps.GetDescription(GpsDirectory.TagLatitude);
+        var lonDesc = gps.GetDescription(GpsDirectory.TagLongitude);
+        if (!string.IsNullOrWhiteSpace(latDesc) && !string.IsNullOrWhiteSpace(lonDesc))
+            fields.Add(new ExifField(L.Get("Exif_GpsLocation"), $"{latDesc}, {lonDesc}"));
     }
 
     private static void AddField(List<ExifField> fields, string label, string? value)

--- a/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
+++ b/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
@@ -28,9 +28,22 @@ public static class ExifReader
         {
             var directories = ImageMetadataReader.ReadMetadata(filePath);
             var summary = BuildSummary(filePath, directories);
-            // Deferred: formatting every tag's description across every directory is only
-            // worth paying for if the user actually clicks "Show All".
-            var all = new Lazy<IReadOnlyList<ExifFieldGroup>>(() => BuildAll(directories));
+            // Deferred: formatting every tag across every directory is only worth paying for if
+            // the user clicks "Show All". This runs later on the UI thread, outside this
+            // try/catch, so guard it here — a descriptor throwing on a malformed tag must not
+            // crash the app, and Lazy would otherwise cache that exception permanently.
+            var all = new Lazy<IReadOnlyList<ExifFieldGroup>>(() =>
+            {
+                try
+                {
+                    return BuildAll(directories);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to build full EXIF tag list for {0}", filePath);
+                    return [];
+                }
+            });
             return new ExifData(summary, all);
         }
         catch (Exception ex)

--- a/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
+++ b/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FlyPhotos.Core.Model;
+using FlyPhotos.Infra.Localization;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using NLog;
+
+namespace FlyPhotos.Display.ExifReading;
+
+// Mirrors the handful of fields a typical photo viewer (Windows Photos,
+// macOS Preview, Google Photos, etc.) surfaces by default, out of the
+// hundreds of raw tags a photo can contain.
+public static class ExifReader
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    public static Task<ExifData> ReadAsync(string filePath) => Task.Run(() => Read(filePath));
+
+    private static ExifData Read(string filePath)
+    {
+        try
+        {
+            var directories = ImageMetadataReader.ReadMetadata(filePath);
+            var summary = BuildSummary(filePath, directories);
+            // Deferred: formatting every tag's description across every directory is only
+            // worth paying for if the user actually clicks "Show All".
+            var all = new Lazy<IReadOnlyList<ExifFieldGroup>>(() => BuildAll(directories));
+            return new ExifData(summary, all);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to read EXIF data for {0}", filePath);
+            return ExifData.Empty;
+        }
+    }
+
+    private static IReadOnlyList<ExifField> BuildSummary(string filePath, IReadOnlyList<MetadataExtractor.Directory> directories)
+    {
+        var ifd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
+        var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+        var gps = directories.OfType<GpsDirectory>().FirstOrDefault();
+        var fileInfo = new FileInfo(filePath);
+
+        var fields = new List<ExifField>();
+        AddField(fields, L.Get("Exif_FileName"), fileInfo.Name);
+        AddField(fields, L.Get("Exif_FileSize"), $"{fileInfo.Length / 1024.0:F1} KB");
+        AddField(fields, L.Get("Exif_DateTaken"), subIfd?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal));
+        AddField(fields, L.Get("Exif_CameraMake"), ifd0?.GetDescription(ExifDirectoryBase.TagMake));
+        AddField(fields, L.Get("Exif_CameraModel"), ifd0?.GetDescription(ExifDirectoryBase.TagModel));
+        AddField(fields, L.Get("Exif_LensModel"), subIfd?.GetDescription(ExifDirectoryBase.TagLensModel));
+        AddField(fields, L.Get("Exif_FocalLength"), subIfd?.GetDescription(ExifDirectoryBase.TagFocalLength));
+        AddField(fields, L.Get("Exif_Aperture"), subIfd?.GetDescription(ExifDirectoryBase.TagFNumber));
+        AddField(fields, L.Get("Exif_ShutterSpeed"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureTime));
+        AddField(fields, L.Get("Exif_Iso"), subIfd?.GetDescription(ExifDirectoryBase.TagIsoEquivalent));
+        AddField(fields, L.Get("Exif_ExposureBias"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureBias));
+        AddField(fields, L.Get("Exif_MeteringMode"), subIfd?.GetDescription(ExifDirectoryBase.TagMeteringMode));
+        AddField(fields, L.Get("Exif_ExposureProgram"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureProgram));
+        AddField(fields, L.Get("Exif_Flash"), subIfd?.GetDescription(ExifDirectoryBase.TagFlash));
+        AddField(fields, L.Get("Exif_Dimensions"), GetDimensions(subIfd));
+        AddField(fields, L.Get("Exif_Orientation"), ifd0?.GetDescription(ExifDirectoryBase.TagOrientation));
+        AddField(fields, L.Get("Exif_ColorSpace"), subIfd?.GetDescription(ExifDirectoryBase.TagColorSpace));
+        AddField(fields, L.Get("Exif_GpsLocation"), GetGpsLocation(gps));
+        return fields;
+    }
+
+    private static IReadOnlyList<ExifFieldGroup> BuildAll(IReadOnlyList<MetadataExtractor.Directory> directories)
+    {
+        var groups = new List<ExifFieldGroup>();
+        foreach (var directory in directories)
+        {
+            var fields = directory.Tags
+                .Where(tag => !string.IsNullOrWhiteSpace(tag.Description))
+                .Select(tag => new ExifField(tag.Name, tag.Description!))
+                .ToList();
+            if (fields.Count > 0) groups.Add(new ExifFieldGroup(directory.Name, fields));
+        }
+        return groups;
+    }
+
+    private static string? GetDimensions(ExifSubIfdDirectory? subIfd)
+    {
+        var width = subIfd?.GetDescription(ExifDirectoryBase.TagExifImageWidth);
+        var height = subIfd?.GetDescription(ExifDirectoryBase.TagExifImageHeight);
+        return width != null && height != null ? $"{width} x {height}" : null;
+    }
+
+    private static string? GetGpsLocation(GpsDirectory? gps)
+    {
+        var latitude = gps?.GetDescription(GpsDirectory.TagLatitude);
+        var longitude = gps?.GetDescription(GpsDirectory.TagLongitude);
+        return latitude != null && longitude != null ? $"{latitude}, {longitude}" : null;
+    }
+
+    private static void AddField(List<ExifField> fields, string label, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value)) fields.Add(new ExifField(label, value));
+    }
+}

--- a/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
+++ b/Src/FlyPhotos/Display/ExifReading/ExifReader.cs
@@ -56,28 +56,32 @@ public static class ExifReader
     private static List<ExifField> BuildSummary(string filePath, IReadOnlyList<MetadataExtractor.Directory> directories)
     {
         var ifd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
-        var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+        // TIFF-based RAW (ARW, NEF, CR2, DNG) emits multiple Exif SubIFD directories: one
+        // describing the raw/preview image structure (no capture settings) and a separate one
+        // holding the real DateTimeOriginal / lens / exposure tags. FirstOrDefault() would pick
+        // the wrong (empty) one, so read each tag from whichever SubIFD actually contains it.
+        var subIfds = directories.OfType<ExifSubIfdDirectory>().ToList();
         var gps = directories.OfType<GpsDirectory>().FirstOrDefault();
         var fileInfo = new FileInfo(filePath);
 
         var fields = new List<ExifField>();
         AddField(fields, L.Get("Exif_FileName"), fileInfo.Name);
         AddField(fields, L.Get("Exif_FileSize"), FormatFileSize(fileInfo.Length));
-        AddField(fields, L.Get("Exif_Dimensions"), GetDimensions(subIfd));
+        AddField(fields, L.Get("Exif_Dimensions"), GetDimensions(subIfds));
         AddField(fields, L.Get("Exif_CameraMake"), ifd0?.GetDescription(ExifDirectoryBase.TagMake));
         AddField(fields, L.Get("Exif_CameraModel"), ifd0?.GetDescription(ExifDirectoryBase.TagModel));
-        AddField(fields, L.Get("Exif_DateTaken"), FormatExifDate(subIfd?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal)));
-        AddField(fields, L.Get("Exif_LensModel"), subIfd?.GetDescription(ExifDirectoryBase.TagLensModel));
-        AddField(fields, L.Get("Exif_FocalLength"), subIfd?.GetDescription(ExifDirectoryBase.TagFocalLength));
-        AddField(fields, L.Get("Exif_Aperture"), subIfd?.GetDescription(ExifDirectoryBase.TagFNumber));
-        AddField(fields, L.Get("Exif_ShutterSpeed"), GetShutterSpeed(subIfd));
-        AddField(fields, L.Get("Exif_Iso"), subIfd?.GetDescription(ExifDirectoryBase.TagIsoEquivalent));
-        AddField(fields, L.Get("Exif_ExposureBias"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureBias));
-        AddField(fields, L.Get("Exif_MeteringMode"), subIfd?.GetDescription(ExifDirectoryBase.TagMeteringMode));
-        AddField(fields, L.Get("Exif_ExposureProgram"), subIfd?.GetDescription(ExifDirectoryBase.TagExposureProgram));
-        AddField(fields, L.Get("Exif_Flash"), subIfd?.GetDescription(ExifDirectoryBase.TagFlash));
+        AddField(fields, L.Get("Exif_DateTaken"), FormatExifDate(SubDescription(subIfds, ExifDirectoryBase.TagDateTimeOriginal)));
+        AddField(fields, L.Get("Exif_LensModel"), SubDescription(subIfds, ExifDirectoryBase.TagLensModel));
+        AddField(fields, L.Get("Exif_FocalLength"), SubDescription(subIfds, ExifDirectoryBase.TagFocalLength));
+        AddField(fields, L.Get("Exif_Aperture"), SubDescription(subIfds, ExifDirectoryBase.TagFNumber));
+        AddField(fields, L.Get("Exif_ShutterSpeed"), GetShutterSpeed(subIfds));
+        AddField(fields, L.Get("Exif_Iso"), SubDescription(subIfds, ExifDirectoryBase.TagIsoEquivalent));
+        AddField(fields, L.Get("Exif_ExposureBias"), SubDescription(subIfds, ExifDirectoryBase.TagExposureBias));
+        AddField(fields, L.Get("Exif_MeteringMode"), SubDescription(subIfds, ExifDirectoryBase.TagMeteringMode));
+        AddField(fields, L.Get("Exif_ExposureProgram"), SubDescription(subIfds, ExifDirectoryBase.TagExposureProgram));
+        AddField(fields, L.Get("Exif_Flash"), SubDescription(subIfds, ExifDirectoryBase.TagFlash));
         AddField(fields, L.Get("Exif_Orientation"), ifd0?.GetDescription(ExifDirectoryBase.TagOrientation));
-        AddField(fields, L.Get("Exif_ColorSpace"), subIfd?.GetDescription(ExifDirectoryBase.TagColorSpace));
+        AddField(fields, L.Get("Exif_ColorSpace"), SubDescription(subIfds, ExifDirectoryBase.TagColorSpace));
         AddGpsField(fields, gps);
         return fields;
     }
@@ -114,10 +118,19 @@ public static class ExifReader
         return groups;
     }
 
-    private static string? GetDimensions(ExifSubIfdDirectory? subIfd)
+    // Finds the SubIFD that carries a given tag (see BuildSummary for why more than one
+    // SubIFD can exist). Null when no SubIFD holds the tag.
+    private static ExifSubIfdDirectory? SubIfdWith(List<ExifSubIfdDirectory> subIfds, int tag)
+        => subIfds.FirstOrDefault(s => s.ContainsTag(tag));
+
+    private static string? SubDescription(List<ExifSubIfdDirectory> subIfds, int tag)
+        => SubIfdWith(subIfds, tag)?.GetDescription(tag);
+
+    private static string? GetDimensions(List<ExifSubIfdDirectory> subIfds)
     {
         // Use the raw pixel counts rather than GetDescription(), which appends
         // a " pixels" unit suffix to each value (e.g. "5472 pixels x 3648 pixels").
+        var subIfd = SubIfdWith(subIfds, ExifDirectoryBase.TagExifImageWidth);
         if (subIfd == null) return null;
         if (!subIfd.TryGetInt32(ExifDirectoryBase.TagExifImageWidth, out var width)) return null;
         if (!subIfd.TryGetInt32(ExifDirectoryBase.TagExifImageHeight, out var height)) return null;
@@ -128,8 +141,9 @@ public static class ExifReader
     // instead of the conventional "1/N sec" notation most viewers show, since many cameras store
     // exposure time as an unreduced fraction rather than a clean 1/N value. Fall back to the raw
     // description for degenerate values (e.g. a bulb-mode 0/1 sentinel) instead of hiding the field.
-    private static string? GetShutterSpeed(ExifSubIfdDirectory? subIfd)
+    private static string? GetShutterSpeed(List<ExifSubIfdDirectory> subIfds)
     {
+        var subIfd = SubIfdWith(subIfds, ExifDirectoryBase.TagExposureTime);
         if (subIfd == null) return null;
         if (subIfd.TryGetDouble(ExifDirectoryBase.TagExposureTime, out var seconds) && seconds > 0)
         {

--- a/Src/FlyPhotos/FlyPhotos.csproj
+++ b/Src/FlyPhotos/FlyPhotos.csproj
@@ -93,6 +93,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="MetadataExtractor" Version="2.9.3" />
 		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />

--- a/Src/FlyPhotos/Strings/ar-SA/Resources.resw
+++ b/Src/FlyPhotos/Strings/ar-SA/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -290,6 +290,72 @@
   </data>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>النوع</value>
+  </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>معلومات الصورة</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>إغلاق</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>عرض الكل</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>عرض الملخص</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>اسم الملف</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>حجم الملف</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>تاريخ الالتقاط</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>الشركة المصنعة للكاميرا</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>طراز الكاميرا</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>طراز العدسة</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>البعد البؤري</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>فتحة العدسة</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>سرعة الغالق</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>تعويض التعريض الضوئي</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>وضع القياس</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>برنامج التعريض الضوئي</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>الفلاش</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>الأبعاد</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>الاتجاه</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>مساحة الألوان</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>موقع GPS</value>
   </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>جارٍ تحميل إصدار عالي الدقة. يرجى الانتظار…</value>

--- a/Src/FlyPhotos/Strings/de-DE/Resources.resw
+++ b/Src/FlyPhotos/Strings/de-DE/Resources.resw
@@ -291,6 +291,72 @@ Einstellungen &gt; Apps &gt; Standard-Apps.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Typ</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Foto-Info</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Alle anzeigen</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Zusammenfassung anzeigen</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Dateiname</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Dateigröße</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Aufnahmedatum</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Kamerahersteller</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Kameramodell</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Objektivmodell</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Brennweite</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Blende</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Verschlusszeit</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Belichtungskorrektur</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Messmodus</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Belichtungsprogramm</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Blitz</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Abmessungen</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Ausrichtung</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Farbraum</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS-Standort</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Hochauflösende Version wird geladen. Bitte warten…</value>
   </data>

--- a/Src/FlyPhotos/Strings/en-US/Resources.resw
+++ b/Src/FlyPhotos/Strings/en-US/Resources.resw
@@ -291,6 +291,72 @@ Settings &gt; Apps &gt; Default apps.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Type</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Photo Info</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Show All</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Show Summary</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>File name</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>File size</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Date taken</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Camera make</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Camera model</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Lens model</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Focal length</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Aperture</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Shutter speed</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Exposure bias</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Metering mode</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Exposure program</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensions</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientation</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Color space</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS location</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Loading high resolution version. Please wait…</value>
   </data>

--- a/Src/FlyPhotos/Strings/es-ES/Resources.resw
+++ b/Src/FlyPhotos/Strings/es-ES/Resources.resw
@@ -291,6 +291,72 @@ Configuración &gt; Aplicaciones &gt; Aplicaciones predeterminadas.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Tipo</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Información de la foto</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Mostrar todo</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Mostrar resumen</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nombre de archivo</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Tamaño de archivo</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Fecha de captura</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Marca de la cámara</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Modelo de la cámara</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Modelo de objetivo</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Distancia focal</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Apertura</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Velocidad de obturación</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Compensación de exposición</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Modo de medición</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Programa de exposición</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensiones</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientación</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Espacio de color</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Ubicación GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Cargando versión de alta resolución. Por favor espere…</value>
   </data>

--- a/Src/FlyPhotos/Strings/fi-FI/Resources.resw
+++ b/Src/FlyPhotos/Strings/fi-FI/Resources.resw
@@ -291,6 +291,72 @@ Asetukset &gt; Sovellukset &gt; Oletussovellukset.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Tyyppi</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Kuvan tiedot</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Sulje</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Näytä kaikki</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Näytä yhteenveto</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Tiedostonimi</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Tiedostokoko</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Kuvauspäivä</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Kameran merkki</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Kameran malli</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Objektiivin malli</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Polttoväli</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Aukko</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Suljinaika</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Valotuksen korjaus</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Mittaustapa</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Valotusohjelma</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Salama</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Mitat</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Suunta</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Väriavaruus</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS-sijainti</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Ladataan korkearesoluutioista versiota. Odota hetki…</value>
   </data>

--- a/Src/FlyPhotos/Strings/fr-FR/Resources.resw
+++ b/Src/FlyPhotos/Strings/fr-FR/Resources.resw
@@ -291,6 +291,72 @@ Paramètres &gt; Applications &gt; Applications par défaut.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Type</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Infos sur la photo</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Tout afficher</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Afficher le résumé</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nom du fichier</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Taille du fichier</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Date de prise de vue</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Marque de l'appareil</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Modèle de l'appareil</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Modèle d'objectif</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Longueur focale</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Ouverture</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Vitesse d'obturation</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Compensation d'exposition</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Mode de mesure</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Programme d'exposition</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensions</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientation</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Espace colorimétrique</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Position GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Chargement de la version haute résolution. Veuillez patienter…</value>
   </data>

--- a/Src/FlyPhotos/Strings/hu-HU/Resources.resw
+++ b/Src/FlyPhotos/Strings/hu-HU/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -289,6 +289,72 @@ Válassza ki a FlyPhotos-t, és válassza a Mindig lehetőséget.</value>
   </data>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Típus</value>
+  </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Fénykép adatai</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Bezárás</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Összes megjelenítése</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Összefoglaló megjelenítése</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Fájlnév</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Fájlméret</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Készítés dátuma</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Fényképezőgép gyártója</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Fényképezőgép modellje</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Objektív modellje</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Gyújtótávolság</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Rekesz</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Záridő</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Expozíciókorrekció</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Fénymérési mód</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Expozíciós program</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Vaku</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Méretek</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Tájolás</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Színtér</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS-hely</value>
   </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Nagy felbontású verzió betöltése. Kérem, várjon…</value>

--- a/Src/FlyPhotos/Strings/it-IT/Resources.resw
+++ b/Src/FlyPhotos/Strings/it-IT/Resources.resw
@@ -291,6 +291,72 @@ Impostazioni &gt; App &gt; App predefinite.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Tipo</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Informazioni foto</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Mostra tutto</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Mostra riepilogo</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nome file</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Dimensione file</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Data acquisizione</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Marca fotocamera</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Modello fotocamera</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Modello obiettivo</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Lunghezza focale</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Apertura</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Velocità otturatore</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Compensazione esposizione</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Metodo di misurazione</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Programma di esposizione</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensioni</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientamento</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Spazio colore</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Posizione GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Caricamento della versione ad alta risoluzione. Attendere prego…</value>
   </data>

--- a/Src/FlyPhotos/Strings/ja-JP/Resources.resw
+++ b/Src/FlyPhotos/Strings/ja-JP/Resources.resw
@@ -290,6 +290,72 @@ FlyPhotosを選択し、「常に」をクリックします。</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>種類</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>写真情報</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>すべて表示</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>概要を表示</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>ファイル名</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>ファイル サイズ</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>撮影日時</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>カメラのメーカー</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>カメラのモデル</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>レンズのモデル</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>焦点距離</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>絞り値</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>シャッタースピード</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>露出補正</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>測光モード</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>露出プログラム</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>フラッシュ</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>寸法</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>向き</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>色空間</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS位置情報</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>高解像度バージョンを読み込み中。お待ちください…</value>
   </data>

--- a/Src/FlyPhotos/Strings/ko-KR/Resources.resw
+++ b/Src/FlyPhotos/Strings/ko-KR/Resources.resw
@@ -290,6 +290,72 @@ FlyPhotos를 선택하고 항상 선택을 선택합니다.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>유형</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>사진 정보</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>모두 표시</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>요약 표시</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>파일 이름</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>파일 크기</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>촬영 일시</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>카메라 제조업체</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>카메라 모델</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>렌즈 모델</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>초점 거리</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>조리개</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>셔터 속도</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>노출 보정</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>측광 모드</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>노출 프로그램</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>플래시</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>크기</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>방향</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>색 공간</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS 위치</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>고해상도 버전을 로드 중입니다. 잠시 기다려 주세요…</value>
   </data>

--- a/Src/FlyPhotos/Strings/ml-IN/Resources.resw
+++ b/Src/FlyPhotos/Strings/ml-IN/Resources.resw
@@ -288,6 +288,72 @@
   <data name="HeaderType.Text" xml:space="preserve">
     <value>തരം</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>ഫോട്ടോ വിവരം</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>അടയ്ക്കുക</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>എല്ലാം കാണിക്കുക</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>ചുരുക്കം കാണിക്കുക</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>ഫയലിന്റെ പേര്</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>ഫയലിന്റെ വലിപ്പം</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>എടുത്ത തീയതി</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>ക്യാമറ നിർമ്മാതാവ്</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>ക്യാമറ മോഡൽ</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>ലെൻസ് മോഡൽ</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>ഫോക്കൽ ലെങ്ത്</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>അപ്പർച്ചർ</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>ഷട്ടർ സ്പീഡ്</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>എക്സ്പോഷർ ബയസ്</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>മീറ്ററിംഗ് മോഡ്</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>എക്സ്പോഷർ പ്രോഗ്രാം</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>ഫ്ലാഷ്</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>അളവുകൾ</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>ഓറിയന്റേഷൻ</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>കളർ സ്പേസ്</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS ലൊക്കേഷൻ</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>കൂടുതൽ വ്യക്തതയുള്ള ചിത്രം ലോഡ് ചെയ്യുന്നു. കുറച്ചു കഴിഞ്ഞ് ശ്രമിക്കുക</value>
   </data>

--- a/Src/FlyPhotos/Strings/nl-NL/Resources.resw
+++ b/Src/FlyPhotos/Strings/nl-NL/Resources.resw
@@ -291,6 +291,72 @@ Instellingen &gt; Apps &gt; Standaard-apps.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Type</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Foto-informatie</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Alles tonen</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Samenvatting tonen</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Bestandsnaam</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Bestandsgrootte</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Opnamedatum</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Cameramerk</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Cameramodel</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Lensmodel</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Brandpuntsafstand</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Diafragma</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Sluitertijd</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Belichtingscompensatie</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Meetmethode</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Belichtingsprogramma</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flitser</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Afmetingen</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Oriëntatie</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Kleurruimte</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS-locatie</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Hoogwaardige versie laden. Even geduld…</value>
   </data>

--- a/Src/FlyPhotos/Strings/pl-PL/Resources.resw
+++ b/Src/FlyPhotos/Strings/pl-PL/Resources.resw
@@ -291,6 +291,72 @@ w Ustawieniach &gt; Aplikacje &gt; Aplikacje domyślne.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Typ</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Informacje o zdjęciu</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Zamknij</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Pokaż wszystko</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Pokaż podsumowanie</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nazwa pliku</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Rozmiar pliku</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Data zrobienia</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Producent aparatu</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Model aparatu</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Model obiektywu</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Ogniskowa</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Przysłona</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Czas otwarcia migawki</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Kompensacja ekspozycji</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Tryb pomiaru</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Program ekspozycji</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Lampa błyskowa</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Wymiary</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientacja</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Przestrzeń kolorów</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Lokalizacja GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Ładowanie wersji w wysokiej rozdzielczości. Proszę czekać…</value>
   </data>

--- a/Src/FlyPhotos/Strings/pt-BR/Resources.resw
+++ b/Src/FlyPhotos/Strings/pt-BR/Resources.resw
@@ -291,6 +291,72 @@ Configurações &gt; Aplicativos &gt; Aplicativos padrão.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Tipo</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Informações da foto</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Mostrar tudo</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Mostrar resumo</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nome do arquivo</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Tamanho do arquivo</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Data de captura</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Fabricante da câmera</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Modelo da câmera</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Modelo da lente</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Distância focal</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Abertura</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Velocidade do obturador</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Compensação de exposição</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Modo de medição</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Programa de exposição</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensões</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientação</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Espaço de cores</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Localização GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Carregando versão em alta resolução. Aguarde…</value>
   </data>

--- a/Src/FlyPhotos/Strings/pt-PT/Resources.resw
+++ b/Src/FlyPhotos/Strings/pt-PT/Resources.resw
@@ -291,6 +291,72 @@ Definições &gt; Aplicações &gt; Aplicações predefinidas.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Tipo</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Informações da fotografia</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Mostrar tudo</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Mostrar resumo</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Nome do ficheiro</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Tamanho do ficheiro</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Data de captura</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Marca da câmara</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Modelo da câmara</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Modelo da objetiva</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Distância focal</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Abertura</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Velocidade do obturador</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Compensação de exposição</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Modo de medição</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Programa de exposição</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Flash</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Dimensões</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientação</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Espaço de cor</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Localização GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>A carregar versão de alta resolução. Aguarde…</value>
   </data>

--- a/Src/FlyPhotos/Strings/ru-RU/Resources.resw
+++ b/Src/FlyPhotos/Strings/ru-RU/Resources.resw
@@ -291,6 +291,72 @@
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Тип</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Информация о фото</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Показать все</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Показать сводку</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Имя файла</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Размер файла</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Дата съемки</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Производитель камеры</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Модель камеры</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Модель объектива</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Фокусное расстояние</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Диафрагма</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Выдержка</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Компенсация экспозиции</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Режим экспозамера</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Программа экспозиции</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Вспышка</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Размеры</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Ориентация</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Цветовое пространство</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Местоположение GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Загрузка версии в высоком разрешении. Пожалуйста, подождите…</value>
   </data>

--- a/Src/FlyPhotos/Strings/sv-SE/Resources.resw
+++ b/Src/FlyPhotos/Strings/sv-SE/Resources.resw
@@ -291,6 +291,72 @@ Inställningar &gt; Appar &gt; Standardappar.</value>
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Typ</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Fotoinformation</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Stäng</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Visa alla</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Visa sammanfattning</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Filnamn</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Filstorlek</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Datum taget</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Kameratillverkare</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Kameramodell</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Objektivmodell</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Brännvidd</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Bländare</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Slutartid</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Exponeringskompensation</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Ljusmätarmetod</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Exponeringsprogram</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Blixt</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Mått</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Orientering</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Färgrymd</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS-plats</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Laddar högupplöst version. Vänta…</value>
   </data>

--- a/Src/FlyPhotos/Strings/uk-UA/Resources.resw
+++ b/Src/FlyPhotos/Strings/uk-UA/Resources.resw
@@ -291,6 +291,72 @@
   <data name="HeaderType.Text" xml:space="preserve">
     <value>Тип</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>Інформація про фото</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>Показати все</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>Показати зведення</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>Ім'я файлу</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>Розмір файлу</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>Дата зйомки</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>Виробник камери</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>Модель камери</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>Модель об'єктива</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>Фокусна відстань</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>Діафрагма</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>Витримка</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>Компенсація експозиції</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>Режим експозаміру</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>Програма експозиції</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>Спалах</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>Розміри</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>Орієнтація</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>Колірний простір</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>Розташування GPS</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>Завантаження версії у високій роздільній здатності. Будь ласка, зачекайте…</value>
   </data>

--- a/Src/FlyPhotos/Strings/zh-CN/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-CN/Resources.resw
@@ -331,7 +331,7 @@
     <value>快门速度</value>
   </data>
   <data name="Exif_Iso" xml:space="preserve">
-    <value>ISO</value>
+    <value>ISO 感光度</value>
   </data>
   <data name="Exif_ExposureBias" xml:space="preserve">
     <value>曝光补偿</value>

--- a/Src/FlyPhotos/Strings/zh-CN/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-CN/Resources.resw
@@ -291,6 +291,72 @@
   <data name="HeaderType.Text" xml:space="preserve">
     <value>类型</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>照片信息</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>显示全部</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>显示摘要</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>文件名</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>文件大小</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>拍摄时间</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>相机制造商</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>相机型号</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>镜头型号</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>焦距</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>光圈</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>快门速度</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>曝光补偿</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>测光模式</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>曝光程序</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>闪光灯</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>尺寸</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>色彩空间</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS位置</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>正在加载高分辨率版本，请稍候…</value>
   </data>

--- a/Src/FlyPhotos/Strings/zh-TW/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-TW/Resources.resw
@@ -291,6 +291,72 @@
   <data name="HeaderType.Text" xml:space="preserve">
     <value>類型</value>
   </data>
+  <data name="ExifPanelTitle.Text" xml:space="preserve">
+    <value>相片資訊</value>
+  </data>
+  <data name="ExifPanelClose.Content" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="Exif_ShowAll" xml:space="preserve">
+    <value>顯示全部</value>
+  </data>
+  <data name="Exif_ShowSummary" xml:space="preserve">
+    <value>顯示摘要</value>
+  </data>
+  <data name="Exif_FileName" xml:space="preserve">
+    <value>檔案名稱</value>
+  </data>
+  <data name="Exif_FileSize" xml:space="preserve">
+    <value>檔案大小</value>
+  </data>
+  <data name="Exif_DateTaken" xml:space="preserve">
+    <value>拍攝時間</value>
+  </data>
+  <data name="Exif_CameraMake" xml:space="preserve">
+    <value>相機製造商</value>
+  </data>
+  <data name="Exif_CameraModel" xml:space="preserve">
+    <value>相機型號</value>
+  </data>
+  <data name="Exif_LensModel" xml:space="preserve">
+    <value>鏡頭型號</value>
+  </data>
+  <data name="Exif_FocalLength" xml:space="preserve">
+    <value>焦距</value>
+  </data>
+  <data name="Exif_Aperture" xml:space="preserve">
+    <value>光圈</value>
+  </data>
+  <data name="Exif_ShutterSpeed" xml:space="preserve">
+    <value>快門速度</value>
+  </data>
+  <data name="Exif_Iso" xml:space="preserve">
+    <value>ISO</value>
+  </data>
+  <data name="Exif_ExposureBias" xml:space="preserve">
+    <value>曝光補償</value>
+  </data>
+  <data name="Exif_MeteringMode" xml:space="preserve">
+    <value>測光模式</value>
+  </data>
+  <data name="Exif_ExposureProgram" xml:space="preserve">
+    <value>曝光程式</value>
+  </data>
+  <data name="Exif_Flash" xml:space="preserve">
+    <value>閃光燈</value>
+  </data>
+  <data name="Exif_Dimensions" xml:space="preserve">
+    <value>尺寸</value>
+  </data>
+  <data name="Exif_Orientation" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="Exif_ColorSpace" xml:space="preserve">
+    <value>色彩空間</value>
+  </data>
+  <data name="Exif_GpsLocation" xml:space="preserve">
+    <value>GPS位置</value>
+  </data>
   <data name="LoadingHighQuality.Message" xml:space="preserve">
     <value>正在載入高解析度版本，請稍候…</value>
   </data>

--- a/Src/FlyPhotos/Strings/zh-TW/Resources.resw
+++ b/Src/FlyPhotos/Strings/zh-TW/Resources.resw
@@ -331,7 +331,7 @@
     <value>快門速度</value>
   </data>
   <data name="Exif_Iso" xml:space="preserve">
-    <value>ISO</value>
+    <value>ISO 感光度</value>
   </data>
   <data name="Exif_ExposureBias" xml:space="preserve">
     <value>曝光補償</value>

--- a/Src/FlyPhotos/ThirdPartyNotices.txt
+++ b/Src/FlyPhotos/ThirdPartyNotices.txt
@@ -905,3 +905,196 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ======================================================================
+9. MetadataExtractor
+Copyright 2002-2025 Drew Noakes and contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+======================================================================

--- a/Src/FlyPhotos/UI/Controls/ExifPanel.xaml
+++ b/Src/FlyPhotos/UI/Controls/ExifPanel.xaml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="FlyPhotos.UI.Controls.ExifPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="ExifPanelBackgroundBrush" Color="#CCFFFFFF" />
+                    <SolidColorBrush x:Key="ExifPanelForegroundBrush" Color="Black" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="ExifPanelBackgroundBrush" Color="#CC1E1E1E" />
+                    <SolidColorBrush x:Key="ExifPanelForegroundBrush" Color="White" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border
+        Width="320"
+        Padding="16"
+        Background="{ThemeResource ExifPanelBackgroundBrush}"
+        CornerRadius="8,0,0,8">
+        <!-- Grid has no Foreground property, so text color is wrapped in a ContentControl
+             (which does) and relies on WinUI's text-property inheritance down to the
+             code-behind-generated field-row TextBlocks. -->
+        <ContentControl
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            Foreground="{ThemeResource ExifPanelForegroundBrush}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock
+                x:Uid="ExifPanelTitle"
+                Grid.Row="0"
+                Margin="0,0,0,12"
+                FontSize="16"
+                FontWeight="SemiBold" />
+
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="FieldsPanel" Spacing="6" />
+            </ScrollViewer>
+
+            <Button
+                x:Name="ButtonToggleMode"
+                Grid.Row="2"
+                Margin="0,12,0,0"
+                HorizontalAlignment="Stretch"
+                Click="ButtonToggleMode_Click" />
+
+            <Button
+                x:Uid="ExifPanelClose"
+                x:Name="ButtonClose"
+                Grid.Row="3"
+                Margin="0,8,0,0"
+                HorizontalAlignment="Stretch"
+                Click="ButtonClose_Click" />
+        </Grid>
+        </ContentControl>
+    </Border>
+</UserControl>

--- a/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
+++ b/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
@@ -1,0 +1,100 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using FlyPhotos.Core.Model;
+using FlyPhotos.Display.ExifReading;
+using FlyPhotos.Infra.Localization;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace FlyPhotos.UI.Controls;
+
+public sealed partial class ExifPanel : UserControl
+{
+    public event Action? CloseRequested;
+
+    private ExifData _data = ExifData.Empty;
+    private bool _showAll;
+    private int _loadToken;
+
+    public ExifPanel()
+    {
+        InitializeComponent();
+    }
+
+    public async Task LoadAsync(string filePath)
+    {
+        var token = ++_loadToken;
+        _showAll = false;
+        ButtonToggleMode.Content = L.Get("Exif_ShowAll");
+        var data = await ExifReader.ReadAsync(filePath);
+        if (token != _loadToken) return; // superseded by a later LoadAsync call
+        _data = data;
+        Render();
+    }
+
+    private void ButtonClose_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke();
+
+    private void ButtonToggleMode_Click(object sender, RoutedEventArgs e)
+    {
+        _showAll = !_showAll;
+        ButtonToggleMode.Content = L.Get(_showAll ? "Exif_ShowSummary" : "Exif_ShowAll");
+        Render();
+    }
+
+    private void Render()
+    {
+        FieldsPanel.Children.Clear();
+
+        if (_showAll)
+        {
+            foreach (var group in _data.All.Value)
+            {
+                FieldsPanel.Children.Add(CreateCategoryHeader(group.Category));
+                foreach (var field in group.Fields) FieldsPanel.Children.Add(CreateFieldRow(field));
+            }
+        }
+        else
+        {
+            foreach (var field in _data.Summary) FieldsPanel.Children.Add(CreateFieldRow(field));
+        }
+    }
+
+    private static UIElement CreateCategoryHeader(string category)
+    {
+        return new TextBlock
+        {
+            Text = category,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Margin = new Thickness(0, 10, 0, 2)
+        };
+    }
+
+    private static UIElement CreateFieldRow(ExifField field)
+    {
+        var grid = new Grid { ColumnSpacing = 12 };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(110) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        var label = new TextBlock
+        {
+            Text = field.Label,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            FontSize = 12
+        };
+        Grid.SetColumn(label, 0);
+
+        var value = new TextBlock
+        {
+            Text = field.Value,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12
+        };
+        Grid.SetColumn(value, 1);
+
+        grid.Children.Add(label);
+        grid.Children.Add(value);
+        return grid;
+    }
+}

--- a/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
+++ b/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
@@ -11,6 +11,8 @@ namespace FlyPhotos.UI.Controls;
 
 public sealed partial class ExifPanel : UserControl
 {
+    private const double FieldFontSize = 12;
+
     public event Action? CloseRequested;
 
     private ExifData _data = ExifData.Empty;
@@ -33,9 +35,9 @@ public sealed partial class ExifPanel : UserControl
         Render();
     }
 
-    private void ButtonClose_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke();
+    private void ButtonClose_Click(object _, RoutedEventArgs _1) => CloseRequested?.Invoke();
 
-    private void ButtonToggleMode_Click(object sender, RoutedEventArgs e)
+    private void ButtonToggleMode_Click(object _, RoutedEventArgs _1)
     {
         _showAll = !_showAll;
         ButtonToggleMode.Content = L.Get(_showAll ? "Exif_ShowSummary" : "Exif_ShowAll");
@@ -60,7 +62,7 @@ public sealed partial class ExifPanel : UserControl
         }
     }
 
-    private static UIElement CreateCategoryHeader(string category)
+    private static TextBlock CreateCategoryHeader(string category)
     {
         return new TextBlock
         {
@@ -70,7 +72,7 @@ public sealed partial class ExifPanel : UserControl
         };
     }
 
-    private static UIElement CreateFieldRow(ExifField field)
+    private static Grid CreateFieldRow(ExifField field)
     {
         var grid = new Grid { ColumnSpacing = 12 };
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(110) });
@@ -81,20 +83,36 @@ public sealed partial class ExifPanel : UserControl
             Text = field.Label,
             TextWrapping = TextWrapping.Wrap,
             Opacity = 0.7,
-            FontSize = 12
+            FontSize = FieldFontSize
         };
         Grid.SetColumn(label, 0);
 
-        var value = new TextBlock
-        {
-            Text = field.Value,
-            TextWrapping = TextWrapping.Wrap,
-            FontSize = 12
-        };
+        FrameworkElement value = field.LinkUrl == null ? CreateValueText(field.Value) : CreateValueLink(field.Value, field.LinkUrl);
         Grid.SetColumn(value, 1);
 
         grid.Children.Add(label);
         grid.Children.Add(value);
         return grid;
+    }
+
+    private static TextBlock CreateValueText(string text)
+    {
+        return new TextBlock
+        {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = FieldFontSize
+        };
+    }
+
+    private static HyperlinkButton CreateValueLink(string text, Uri url)
+    {
+        return new HyperlinkButton
+        {
+            Content = text,
+            NavigateUri = url,
+            Padding = new Thickness(0),
+            FontSize = FieldFontSize
+        };
     }
 }

--- a/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
+++ b/Src/FlyPhotos/UI/Controls/ExifPanel.xaml.cs
@@ -13,29 +13,62 @@ public sealed partial class ExifPanel : UserControl
 {
     private const double FieldFontSize = 12;
 
-    public event Action? CloseRequested;
-
     private ExifData _data = ExifData.Empty;
     private bool _showAll;
     private int _loadToken;
+    private string? _loadedFilePath;
 
     public ExifPanel()
     {
         InitializeComponent();
     }
 
-    public async Task LoadAsync(string filePath)
+    public void Toggle(string filePath)
+    {
+        if (IsOpen) Close();
+        else Open(filePath);
+    }
+
+    // Dismiss the panel when the app navigates to a different file, but stay open on a
+    // same-file refresh (e.g. preview -> HQ upgrade). Full paths are unique, so they
+    // distinguish real navigation from two same-named files in different folders.
+    public void CloseIfFileChanged(string currentFilePath)
+    {
+        if (IsOpen && !IsShowing(currentFilePath)) Close();
+    }
+
+    private bool IsOpen => Visibility == Visibility.Visible;
+
+    private bool IsShowing(string filePath) =>
+        string.Equals(_loadedFilePath, filePath, StringComparison.OrdinalIgnoreCase);
+
+    private void Open(string filePath)
+    {
+        Visibility = Visibility.Visible;
+        _ = LoadAsync(filePath);
+    }
+
+    private void Close() => Visibility = Visibility.Collapsed;
+
+    private async Task LoadAsync(string filePath)
     {
         var token = ++_loadToken;
+        _loadedFilePath = filePath;
         _showAll = false;
         ButtonToggleMode.Content = L.Get("Exif_ShowAll");
+
+        // Clear the previous photo's rows synchronously (before the await) so they don't
+        // linger in the visible panel while the new file's metadata is read in the background.
+        _data = ExifData.Empty;
+        Render();
+
         var data = await ExifReader.ReadAsync(filePath);
         if (token != _loadToken) return; // superseded by a later LoadAsync call
         _data = data;
         Render();
     }
 
-    private void ButtonClose_Click(object _, RoutedEventArgs _1) => CloseRequested?.Invoke();
+    private void ButtonClose_Click(object _, RoutedEventArgs _1) => Close();
 
     private void ButtonToggleMode_Click(object _, RoutedEventArgs _1)
     {

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:FlyPhotos.UI.Behaviors"
+    xmlns:controls="using:FlyPhotos.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:win2d="using:Microsoft.Graphics.Canvas.UI.Xaml"
@@ -44,22 +45,6 @@
             Background="Transparent"
             ClearColor="Transparent"
             IsFixedTimeStep="False" />
-        <Button
-            x:Name="ButtonFullScreenClose"
-            Width="30"
-            Height="30"
-            Padding="0"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Top"
-            Background="#66000000"
-            BorderBrush="Transparent"
-            Click="ButtonFullScreenClose_Click"
-            Content="&#xE8BB;"
-            CornerRadius="0,0,0,15"
-            FontFamily="{StaticResource FluentIcons}"
-            FontSize="10"
-            Foreground="White"
-            Visibility="Collapsed" />
         <Border
             x:Name="BorderTxtZoom"
             Padding="10,5,10,5"
@@ -297,6 +282,30 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
         </StackPanel>
+
+        <controls:ExifPanel
+            x:Name="ExifInfoPanel"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Stretch"
+            CloseRequested="ExifInfoPanel_CloseRequested"
+            Visibility="Collapsed" />
+
+        <Button
+            x:Name="ButtonFullScreenClose"
+            Width="30"
+            Height="30"
+            Padding="0"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Background="#66000000"
+            BorderBrush="Transparent"
+            Click="ButtonFullScreenClose_Click"
+            Content="&#xE8BB;"
+            CornerRadius="0,0,0,15"
+            FontFamily="{StaticResource FluentIcons}"
+            FontSize="10"
+            Foreground="White"
+            Visibility="Collapsed" />
 
     </behaviors:CursorHost>
 </Window>

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml
@@ -287,7 +287,6 @@
             x:Name="ExifInfoPanel"
             HorizontalAlignment="Right"
             VerticalAlignment="Stretch"
-            CloseRequested="ExifInfoPanel_CloseRequested"
             Visibility="Collapsed" />
 
         <Button

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
@@ -225,7 +225,7 @@ public sealed partial class PhotoDisplayWindow
             // File properties
             [(VirtualKey.Enter, false, true)] = Act(() => Util.ShowFileProperties(_photoController.GetFullPathCurrentFile())),
             [(VirtualKey.D,     false, false)] = Act(() => Util.ShowFileProperties(_photoController.GetFullPathCurrentFile(), true)),
-            [(VirtualKey.I,     false, false)] = Act(ToggleExifPanel),
+            [(VirtualKey.I,     false, false)] = Act(() => ExifInfoPanel.Toggle(_photoController.GetFullPathCurrentFile())),
 
             // External apps
             [(VirtualKey.E,          false, false)] = Act(() => ButtonShortcuts_OnClick(ButtonShortcuts, new RoutedEventArgs())),
@@ -379,28 +379,6 @@ public sealed partial class PhotoDisplayWindow
         _cacheStatusExpanded = !_cacheStatusExpanded;
         IconExpander.Text = ((char)(_cacheStatusExpanded ? 0xE760 : 0xE761)).ToString();
         CacheStatusProgress.Visibility = _cacheStatusExpanded ? Visibility.Visible : Visibility.Collapsed;
-    }
-
-    private void ExifInfoPanel_CloseRequested() => CloseExifPanel();
-
-    private bool ExifPanelOpen => ExifInfoPanel.Visibility == Visibility.Visible;
-
-    private void ToggleExifPanel()
-    {
-        if (ExifPanelOpen) CloseExifPanel();
-        else OpenExifPanel();
-    }
-
-    private void OpenExifPanel()
-    {
-        ExifInfoPanel.Visibility = Visibility.Visible;
-        _ = ExifInfoPanel.LoadAsync(_photoController.GetFullPathCurrentFile());
-    }
-
-    private void CloseExifPanel()
-    {
-        if (!ExifPanelOpen) return;
-        ExifInfoPanel.Visibility = Visibility.Collapsed;
     }
 
     private void ButtonSettings_OnClick(object sender, RoutedEventArgs e)
@@ -737,9 +715,7 @@ public sealed partial class PhotoDisplayWindow
     {
         DispatcherQueue.TryEnqueue(() =>
         {
-            // This event also fires when the same photo upgrades from preview to HQ, not just on
-            // real navigation; comparing against the still-previous Title tells the two apart.
-            if (ExifPanelOpen && Title != fileDisplayDetails.FileName) CloseExifPanel();
+            ExifInfoPanel.CloseIfFileChanged(_photoController.GetFullPathCurrentFile());
             TxtFileName.Text = fileDisplayDetails.DisplayText;
             Title = fileDisplayDetails.FileName;
         });

--- a/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
+++ b/Src/FlyPhotos/UI/Views/PhotoDisplayWindow.xaml.cs
@@ -225,6 +225,7 @@ public sealed partial class PhotoDisplayWindow
             // File properties
             [(VirtualKey.Enter, false, true)] = Act(() => Util.ShowFileProperties(_photoController.GetFullPathCurrentFile())),
             [(VirtualKey.D,     false, false)] = Act(() => Util.ShowFileProperties(_photoController.GetFullPathCurrentFile(), true)),
+            [(VirtualKey.I,     false, false)] = Act(ToggleExifPanel),
 
             // External apps
             [(VirtualKey.E,          false, false)] = Act(() => ButtonShortcuts_OnClick(ButtonShortcuts, new RoutedEventArgs())),
@@ -378,6 +379,28 @@ public sealed partial class PhotoDisplayWindow
         _cacheStatusExpanded = !_cacheStatusExpanded;
         IconExpander.Text = ((char)(_cacheStatusExpanded ? 0xE760 : 0xE761)).ToString();
         CacheStatusProgress.Visibility = _cacheStatusExpanded ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void ExifInfoPanel_CloseRequested() => CloseExifPanel();
+
+    private bool ExifPanelOpen => ExifInfoPanel.Visibility == Visibility.Visible;
+
+    private void ToggleExifPanel()
+    {
+        if (ExifPanelOpen) CloseExifPanel();
+        else OpenExifPanel();
+    }
+
+    private void OpenExifPanel()
+    {
+        ExifInfoPanel.Visibility = Visibility.Visible;
+        _ = ExifInfoPanel.LoadAsync(_photoController.GetFullPathCurrentFile());
+    }
+
+    private void CloseExifPanel()
+    {
+        if (!ExifPanelOpen) return;
+        ExifInfoPanel.Visibility = Visibility.Collapsed;
     }
 
     private void ButtonSettings_OnClick(object sender, RoutedEventArgs e)
@@ -714,6 +737,9 @@ public sealed partial class PhotoDisplayWindow
     {
         DispatcherQueue.TryEnqueue(() =>
         {
+            // This event also fires when the same photo upgrades from preview to HQ, not just on
+            // real navigation; comparing against the still-previous Title tells the two apart.
+            if (ExifPanelOpen && Title != fileDisplayDetails.FileName) CloseExifPanel();
             TxtFileName.Text = fileDisplayDetails.DisplayText;
             Title = fileDisplayDetails.FileName;
         });


### PR DESCRIPTION
Adds an on-demand EXIF/metadata panel, toggled with the I key.

What it does

- I toggles a right-side panel for the current photo.
- Summary view of the common fields (dimensions, camera, date, lens, aperture, shutter, ISO, GPS, etc.), plus a Show All toggle that lazily dumps every tag.
- GPS renders as a clickable Google Maps link.
- Fully localized across all 23 locales.

Formatting & correctness

- Sizes in KB/MB/GB; dates as 2023-08-03; dimensions as 6000 × 4000; shutter as 1/50 s (not the raw EXIF rational).

Panel lifecycle

- Panel owns its visibility (Toggle / CloseIfFileChanged); dismisses on real navigation (by full path) but stays open across a same-file preview→HQ refresh. Load races are token-guarded and a malformed tag can't crash the app.

Ref #196